### PR TITLE
feat: Implement CoAP observer, output sending, and option handling

### DIFF
--- a/pkg/converter/coap_message_converter_test.go
+++ b/pkg/converter/coap_message_converter_test.go
@@ -4,12 +4,18 @@ import (
 	"bytes"
 	"compress/gzip" // Added for GzippedData test
 	"compress/zlib"
+	"encoding/hex"
 	"io"
+	"sort"
 	"strings"
 	"testing"
 
-	"github.com/plgd-dev/go-coap/v3/message" // Required for constructing CoAP messages
+	"github.com/plgd-dev/go-coap/v3/message"
+	"github.com/plgd-dev/go-coap/v3/message/codes"
+	"github.com/plgd-dev/go-coap/v3/message/pool"
 	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Helper function to compress data with zlib (deflate)
@@ -141,6 +147,368 @@ func TestDecompressDeflate(t *testing.T) {
 			t.Logf("Received error for corrupted data: %v. Expected checksum error or unexpected EOF.", err)
 		}
 	})
+}
+
+func TestMessageToCoAP_ContentFormat(t *testing.T) {
+	logger := service.MockLogger()
+	tests := []struct {
+		name                 string
+		config               Config
+		benthosMsg           *service.Message
+		expectedContentFormat uint32
+		expectError          bool
+	}{
+		{
+			name: "from coap_content_format metadata",
+			config: Config{},
+			benthosMsg: func() *service.Message {
+				msg := service.NewMessage([]byte("hello"))
+				msg.MetaSet("coap_content_format", "50") // application/json
+				return msg
+			}(),
+			expectedContentFormat: message.AppJSON,
+		},
+		{
+			name: "from content_type metadata",
+			config: Config{},
+			benthosMsg: func() *service.Message {
+				msg := service.NewMessage([]byte("hello"))
+				msg.MetaSet("content_type", "application/xml")
+				return msg
+			}(),
+			expectedContentFormat: message.AppXML,
+		},
+		{
+			name: "auto-detect JSON",
+			config: Config{},
+			benthosMsg: service.NewMessage([]byte(`{"key":"value"}`)),
+			expectedContentFormat: message.AppJSON,
+		},
+		{
+			name: "auto-detect XML",
+			config: Config{},
+			benthosMsg: service.NewMessage([]byte(`<tag>value</tag>`)),
+			expectedContentFormat: message.AppXML,
+		},
+		{
+			name: "auto-detect plain text",
+			config: Config{},
+			benthosMsg: service.NewMessage([]byte(`hello plain text`)),
+			expectedContentFormat: message.TextPlain,
+		},
+		{
+			name: "default to AppOctets for non-textual",
+			config: Config{},
+			benthosMsg: service.NewMessage([]byte{0x01, 0x02, 0x03, 0xFF}), // some binary
+			expectedContentFormat: message.AppOctets,
+		},
+		{
+			name: "empty payload results in text plain",
+			config: Config{},
+			benthosMsg: service.NewMessage([]byte{}),
+			expectedContentFormat: message.TextPlain,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conv := NewConverter(tt.config, logger)
+			coapMsg, err := conv.MessageToCoAP(tt.benthosMsg)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, coapMsg)
+
+			cf, err := coapMsg.Options().GetUint32(message.ContentFormat)
+			require.NoError(t, err, "ContentFormat option should be present")
+			assert.Equal(t, tt.expectedContentFormat, cf)
+		})
+	}
+}
+
+func TestCoAPMessageOptionPreservation(t *testing.T) {
+	logger := service.MockLogger()
+	converter := NewConverter(Config{PreserveOptions: true}, logger)
+
+	t.Run("CoAPToMessage then MessageToCoAP", func(t *testing.T) {
+		// 1. CoAPToMessage (Preserve CoAP options to Benthos metadata)
+		coapIn := pool.AcquireMessage(message.TODO)
+		defer pool.ReleaseMessage(coapIn)
+		coapIn.SetCode(codes.Content)
+		coapIn.SetToken(message.Token("token1"))
+		coapIn.SetPayload([]byte("payload"))
+
+		// Add options that should be preserved
+		require.NoError(t, coapIn.AddOptionBytes(message.OptionID(2000), []byte("custom_opt_val_1"))) // Custom option
+		require.NoError(t, coapIn.AddOptionString(message.OptionID(2001), "custom_opt_val_2_str"))
+		require.NoError(t, coapIn.AddOptionBytes(message.OptionID(2000), []byte("custom_opt_val_1_repeated"))) // Repeated custom option
+
+		// Add options that should be skipped by generic preservation (handled by specific metadata)
+		require.NoError(t, coapIn.SetOptionUint32(message.MaxAge, 60))
+		require.NoError(t, coapIn.SetPathString("/skipped/path"))
+
+
+		benthosMsg, err := converter.CoAPToMessage(coapIn)
+		require.NoError(t, err)
+		require.NotNil(t, benthosMsg)
+
+		// Verify specific metadata
+		v, exists := benthosMsg.MetaGet("coap_max_age")
+		assert.True(t, exists)
+		assert.Equal(t, "60", v)
+		v, exists = benthosMsg.MetaGet("coap_uri_path")
+		assert.True(t, exists)
+		assert.Equal(t, "/skipped/path", v)
+
+
+		// Verify preserved generic options
+		expectedMetaKey1 := "coap_option_2000_0"
+		expectedMetaVal1 := hex.EncodeToString([]byte("custom_opt_val_1"))
+		v, exists = benthosMsg.MetaGet(expectedMetaKey1)
+		assert.True(t, exists, "Expected metadata key %s", expectedMetaKey1)
+		assert.Equal(t, expectedMetaVal1, v)
+
+		expectedMetaKey2 := "coap_option_2001_0"
+		expectedMetaVal2 := hex.EncodeToString([]byte("custom_opt_val_2_str"))
+		v, exists = benthosMsg.MetaGet(expectedMetaKey2)
+		assert.True(t, exists, "Expected metadata key %s", expectedMetaKey2)
+		assert.Equal(t, expectedMetaVal2, v)
+
+		expectedMetaKey3 := "coap_option_2000_1" // Second occurrence of option 2000
+		expectedMetaVal3 := hex.EncodeToString([]byte("custom_opt_val_1_repeated"))
+		v, exists = benthosMsg.MetaGet(expectedMetaKey3)
+		assert.True(t, exists, "Expected metadata key %s for repeated option", expectedMetaKey3)
+		assert.Equal(t, expectedMetaVal3, v)
+
+
+		// Verify skipped options are not in generic metadata
+		_, exists = benthosMsg.MetaGet("coap_option_14_0") // MaxAge (14)
+		assert.False(t, exists, "MaxAge should not be in generic preserved options")
+		_, exists = benthosMsg.MetaGet("coap_option_11_0") // UriPath (11)
+		assert.False(t, exists, "UriPath should not be in generic preserved options")
+
+		// 2. MessageToCoAP (Restore options from Benthos metadata to CoAP message)
+		// We need to remove the specific metadata that preserveAllOptions would skip,
+		// so that addOptionsFromMetadata relies on the generic preserved ones for these.
+		// No, this is not correct. `addOptionsFromMetadata` will use specific keys if present,
+		// then generic ones. `preserveAllOptions` already skips specific ones.
+		// So the benthosMsg is fine as is.
+
+		coapOut, err := converter.MessageToCoAP(benthosMsg)
+		require.NoError(t, err)
+		require.NotNil(t, coapOut)
+
+		// Verify restored options
+		opts := coapOut.Options()
+		var restoredOpt2000Values [][]byte
+		var restoredOpt2001Values []string
+		var restoredMaxAge uint32
+		var restoredPath string
+
+		restoredPath, _ = coapOut.Options().Path()
+		restoredMaxAge, _ = coapOut.Options().GetUint32(message.MaxAge)
+
+
+		for _, opt := range opts {
+			if opt.ID == message.OptionID(2000) {
+				restoredOpt2000Values = append(restoredOpt2000Values, opt.Value)
+			}
+			if opt.ID == message.OptionID(2001) {
+				restoredOpt2001Values = append(restoredOpt2001Values, string(opt.Value))
+			}
+		}
+
+		assert.Equal(t, "/skipped/path", restoredPath, "Path from specific metadata should be restored")
+		assert.Equal(t, uint32(60), restoredMaxAge, "MaxAge from specific metadata should be restored")
+
+		require.Len(t, restoredOpt2000Values, 2, "Should have two instances of option ID 2000")
+		assert.Contains(t, restoredOpt2000Values, []byte("custom_opt_val_1"))
+		assert.Contains(t, restoredOpt2000Values, []byte("custom_opt_val_1_repeated"))
+
+		require.Len(t, restoredOpt2001Values, 1, "Should have one instance of option ID 2001")
+		assert.Contains(t, restoredOpt2001Values, "custom_opt_val_2_str")
+	})
+}
+
+
+func TestMessageToCoAP_SpecificOptionSetting(t *testing.T) {
+	logger := service.MockLogger()
+	// Test with PreserveOptions = false to isolate specific logic
+	converter := NewConverter(Config{PreserveOptions: false}, logger)
+
+	tests := []struct {
+		name          string
+		meta          map[string]string
+		verifyOpt     func(t *testing.T, opts message.Options)
+		expectedError bool
+	}{
+		{
+			name: "set Uri-Path",
+			meta: map[string]string{"coap_uri_path": "/sensors/temp"},
+			verifyOpt: func(t *testing.T, opts message.Options) {
+				path, err := opts.Path()
+				require.NoError(t, err)
+				assert.Equal(t, "sensors/temp", path)
+			},
+		},
+		{
+			name: "set Uri-Query",
+			meta: map[string]string{"coap_uri_query": "rt=temperature&unit=celsius"},
+			verifyOpt: func(t *testing.T, opts message.Options) {
+				queries, err := opts.Queries()
+				require.NoError(t, err)
+				assert.Contains(t, queries, "rt=temperature")
+				assert.Contains(t, queries, "unit=celsius")
+			},
+		},
+		{
+			name: "set Max-Age",
+			meta: map[string]string{"coap_max_age": "120"},
+			verifyOpt: func(t *testing.T, opts message.Options) {
+				val, err := opts.GetUint32(message.MaxAge)
+				require.NoError(t, err)
+				assert.Equal(t, uint32(120), val)
+			},
+		},
+		{
+			name: "set ETag",
+			meta: map[string]string{"coap_etag": "simpleTag"},
+			verifyOpt: func(t *testing.T, opts message.Options) {
+				val, err := opts.GetBytes(message.ETag)
+				require.NoError(t, err)
+				assert.Equal(t, []byte("simpleTag"), val)
+			},
+		},
+		{
+			name: "set Observe register",
+			meta: map[string]string{"coap_observe_request": "register"},
+			verifyOpt: func(t *testing.T, opts message.Options) {
+				val, err := opts.GetUint32(message.Observe)
+				require.NoError(t, err)
+				assert.Equal(t, uint32(0), val)
+			},
+		},
+		{
+			name: "set Observe deregister",
+			meta: map[string]string{"coap_observe_request": "1"},
+			verifyOpt: func(t *testing.T, opts message.Options) {
+				val, err := opts.GetUint32(message.Observe)
+				require.NoError(t, err)
+				assert.Equal(t, uint32(1), val)
+			},
+		},
+		{
+			name: "set Accept",
+			meta: map[string]string{"coap_accept": "50"}, // application/json
+			verifyOpt: func(t *testing.T, opts message.Options) {
+				val, err := opts.GetUint32(message.Accept)
+				require.NoError(t, err)
+				assert.Equal(t, uint32(50), val)
+			},
+		},
+		{
+			name: "set If-Match (single hex string)",
+			meta: map[string]string{"coap_if_match": hex.EncodeToString([]byte{0x01, 0x02})},
+			verifyOpt: func(t *testing.T, opts message.Options) {
+				// GetOptionBytes returns first if multiple, GetOptions returns slice
+				vals, err := opts.GetOptionBytes(message.IfMatch) // Returns first if multiple
+				require.NoError(t, err)
+				assert.Equal(t, []byte{0x01, 0x02}, vals)
+			},
+		},
+		{
+			name: "set If-None-Match",
+			meta: map[string]string{"coap_if_none_match": "true"},
+			verifyOpt: func(t *testing.T, opts message.Options) {
+				_, err := opts.GetOptionBytes(message.IfNoneMatch) // Check for presence
+				require.NoError(t, err) // If present, err is nil, value is empty []byte
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bMsg := service.NewMessage(nil)
+			for k, v := range tt.meta {
+				bMsg.MetaSet(k, v)
+			}
+
+			coapMsg, err := converter.MessageToCoAP(bMsg)
+			if tt.expectedError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, coapMsg)
+			tt.verifyOpt(t, coapMsg.Options())
+		})
+	}
+}
+
+
+func TestMessageToCoAP_SpecificOptionPrecedence(t *testing.T) {
+	logger := service.MockLogger()
+	// Test with PreserveOptions = true to check precedence
+	converter := NewConverter(Config{PreserveOptions: true}, logger)
+
+	bMsg := service.NewMessage(nil)
+	// Specific metadata for ETag
+	bMsg.MetaSet("coap_etag", "specific-etag-value")
+	// Generic preserved option for ETag (ID 4)
+	bMsg.MetaSet("coap_option_4_0", hex.EncodeToString([]byte("generic-etag-value")))
+
+	coapMsg, err := converter.MessageToCoAP(bMsg)
+	require.NoError(t, err)
+	require.NotNil(t, coapMsg)
+
+	// Verify that the specific ETag is used
+	etagBytes, err := coapMsg.Options().GetBytes(message.ETag)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("specific-etag-value"), etagBytes)
+
+	// Verify that the generic one was NOT added additionally if SetOptionBytes was used for specific.
+	// If AddOptionBytes was used, there might be two. ETag is usually single.
+	// Our specific handler uses SetOptionBytes.
+	// The generic restore logic has a safeguard to skip ID 4 if coap_option_4_0 is encountered.
+
+	// Let's check how many ETag options are there. Should be 1.
+	count := 0
+	for _, opt := range coapMsg.Options() {
+		if opt.ID == message.ETag {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "Only one ETag option should be present, set by specific metadata")
+}
+
+// Test for MessageToCoAP to ensure correct URI path and query formation
+// when PreserveOptions is false (generic options are not processed).
+func TestMessageToCoAP_PathAndQuery_NoPreserve(t *testing.T) {
+	logger := service.MockLogger()
+	converterNoPreserve := NewConverter(Config{PreserveOptions: false}, logger)
+
+	bMsg := service.NewMessage([]byte("test payload"))
+	bMsg.MetaSet("coap_uri_path", "/my/path")
+	bMsg.MetaSet("coap_uri_query", "q1=v1&q2=v2")
+	// Add a generic option that should be ignored
+	bMsg.MetaSet("coap_option_100_0", "ignored")
+
+
+	coapMsg, err := converterNoPreserve.MessageToCoAP(bMsg)
+	require.NoError(t, err)
+	require.NotNil(t, coapMsg)
+
+	path, _ := coapMsg.Options().Path()
+	assert.Equal(t, "my/path", path)
+
+	queries, _ := coapMsg.Options().Queries()
+	assert.ElementsMatch(t, []string{"q1=v1", "q2=v2"}, queries)
+
+	// Check that the generic option was ignored
+	_, err = coapMsg.Options().GetOptionBytes(message.OptionID(100))
+	assert.Error(t, err, "Generic option should not be present when PreserveOptions is false")
 }
 
 // Helper function to compress data with gzip

--- a/pkg/observer/coap_observer_manager_test.go
+++ b/pkg/observer/coap_observer_manager_test.go
@@ -1,0 +1,651 @@
+package observer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/plgd-dev/go-coap/v3/message"
+	"github.com/plgd-dev/go-coap/v3/message/codes"
+	"github.com/plgd-dev/go-coap/v3/message/pool"
+	coapNet "github.com/plgd-dev/go-coap/v3/net"
+	"github.com/plgd-dev/go-coap/v3/options"
+	"github.com/plgd-dev/go-coap/v3/udp/client"
+	tcpClient "github.com/plgd-dev/go-coap/v3/tcp/client"
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/twinfer/benthos-coap-plugin/pkg/connection"
+	"github.com/twinfer/benthos-coap-plugin/pkg/converter"
+)
+
+// --- Mocks ---
+
+// MockConnectionWrapper
+type MockConnectionWrapper struct {
+	mock.Mock
+	conn      interface{}
+	protocol  string
+	endpoint  string
+	closed    bool
+	closeChan chan struct{}
+}
+
+func NewMockConnectionWrapper(conn interface{}, protocol, endpoint string) *MockConnectionWrapper {
+	return &MockConnectionWrapper{
+		conn:      conn,
+		protocol:  protocol,
+		endpoint:  endpoint,
+		closeChan: make(chan struct{}),
+	}
+}
+func (m *MockConnectionWrapper) Connection() interface{} { return m.conn }
+func (m *MockConnectionWrapper) Protocol() string      { return m.protocol }
+func (m *MockConnectionWrapper) Endpoint() string      { return m.endpoint }
+func (m *MockConnectionWrapper) Close() error {
+	if m.closed {
+		return errors.New("already closed")
+	}
+	m.closed = true
+	close(m.closeChan)
+	return m.Called().Error(0)
+}
+func (m *MockConnectionWrapper) Closed() <-chan struct{} { return m.closeChan }
+func (m *MockConnectionWrapper) Healthy() bool           { return !m.closed }
+
+
+// MockConnectionManager
+type MockConnectionManager struct {
+	mock.Mock
+}
+
+func (m *MockConnectionManager) Get(ctx context.Context) (*connection.ConnectionWrapper, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*connection.ConnectionWrapper), args.Error(1)
+}
+func (m *MockConnectionManager) Put(conn *connection.ConnectionWrapper) { m.Called(conn) }
+func (m *MockConnectionManager) Config() connection.Config {
+	args := m.Called()
+	return args.Get(0).(connection.Config)
+}
+func (m *MockConnectionManager) Close() error { return m.Called().Error(0) }
+
+// MockConverter
+type MockConverter struct {
+	mock.Mock
+}
+
+func (m *MockConverter) CoAPToMessage(coapMsg *message.Message) (*service.Message, error) {
+	args := m.Called(coapMsg)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*service.Message), args.Error(1)
+}
+func (m *MockConverter) MessageToCoAP(msg *service.Message) (*message.Message, error) {
+	args := m.Called(msg)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*message.Message), args.Error(1)
+}
+
+// MockUDPClientConn
+type MockUDPClientConn struct {
+	mock.Mock
+	client.Conn // Embed to satisfy interface, but methods will be mocked
+	observeFunc func(ctx context.Context, path string, observeFunc func(notification *message.Message), opts ...options.Option) (message.Token, error)
+}
+
+func (m *MockUDPClientConn) Observe(ctx context.Context, path string, observeFunc func(notification *message.Message), opts ...options.Option) (message.Token, error) {
+	if m.observeFunc != nil {
+		return m.observeFunc(ctx, path, observeFunc, opts...)
+	}
+	args := m.Called(ctx, path, observeFunc, opts)
+	return args.Get(0).(message.Token), args.Error(1)
+}
+func (m *MockUDPClientConn) Close() error { return m.Called().Error(0) }
+func (m *MockUDPClientConn) Ping(ctx context.Context) error { return m.Called(ctx).Error(0) }
+func (m *MockUDPClientConn) RemoteAddr() coapNet.Addr { return nil } // Implement other necessary methods if they get called
+func (m *MockUDPClientConn) Context() context.Context { return context.Background() }
+
+
+// MockTCPClientConn
+type MockTCPClientConn struct {
+	mock.Mock
+	tcpClient.Conn // Embed to satisfy interface
+	observeFunc func(ctx context.Context, path string, observeFunc func(notification *message.Message), opts ...options.Option) (*tcpClient.Observation, error)
+}
+func (m *MockTCPClientConn) Observe(ctx context.Context, path string, observeFunc func(notification *message.Message), opts ...options.Option) (*tcpClient.Observation, error) {
+	if m.observeFunc != nil {
+		return m.observeFunc(ctx, path, observeFunc, opts...)
+	}
+	args := m.Called(ctx, path, observeFunc, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*tcpClient.Observation), args.Error(1)
+}
+func (m *MockTCPClientConn) Close() error { return m.Called().Error(0) }
+func (m *MockTCPClientConn) Ping(ctx context.Context) error { return m.Called(ctx).Error(0) }
+func (m *MockTCPClientConn) RemoteAddr() coapNet.Addr { return nil }
+func (m *MockTCPClientConn) Context() context.Context { return context.Background() }
+
+
+// MockTCPObservation
+type MockTCPObservation struct {
+	mock.Mock
+	token message.Token
+}
+func (m *MockTCPObservation) Token() message.Token { return m.token }
+func (m *MockTCPObservation) Cancel(ctx context.Context) error { return m.Called(ctx).Error(0) }
+func (m *MockTCPObservation) Canceled() bool { args := m.Called(); return args.Bool(0) }
+
+
+// --- Test Suite Setup ---
+func newTestManager(t *testing.T, config Config) (*Manager, *MockConnectionManager, *MockConverter) {
+	logger := service.MockLogger()
+	mockConnMgr := new(MockConnectionManager)
+	mockConv := new(MockConverter)
+
+	// Default config for connManager if not specified by test
+	connMgrConfig := connection.Config{
+		Endpoints: []string{"coap://localhost:5683"},
+		Protocol: "udp",
+	}
+	mockConnMgr.On("Config").Return(connMgrConfig).Maybe()
+
+
+	mgr, err := NewManager(config, mockConnMgr, mockConv, logger, service.MockResources())
+	require.NoError(t, err)
+	require.NotNil(t, mgr)
+	return mgr, mockConnMgr, mockConv
+}
+
+// --- Tests ---
+
+func TestManager_HandleObserveMessage_Success(t *testing.T) {
+	mgr, _, mockConv := newTestManager(t, Config{})
+	defer mgr.Close()
+
+	path := "/test/resource"
+	token, _ := message.GetToken()
+	coapMsg := pool.AcquireMessage(context.Background())
+	defer pool.ReleaseMessage(coapMsg)
+	coapMsg.SetCode(codes.Content)
+	coapMsg.SetToken(token)
+	coapMsg.SetBody(strings.NewReader("test payload"))
+	coapMsg.SetObserve(10)
+
+	benthosMsg := service.NewMessage([]byte("converted payload"))
+	mockConv.On("CoAPToMessage", coapMsg).Return(benthosMsg, nil)
+
+	// Need a subscription for handleObserveMessage to find
+	mockUDPConn := new(MockUDPClientConn)
+	mockUDPConn.On("Close").Return(nil).Maybe() // For when subscription is closed
+
+	connWrapper := connection.NewConnectionWrapper(mockUDPConn, "udp", "localhost:5683", nil, service.MockLogger())
+
+	subCtx, cancelSub := context.WithCancel(context.Background())
+	defer cancelSub()
+
+	sub := &Subscription{
+		path:    path,
+		conn:    connWrapper,
+		circuit: NewCircuitBreaker(DefaultCircuitConfig()),
+		cancel:  cancelSub,
+		healthy: 1,
+	}
+	mgr.subscriptions[path] = sub
+
+
+	mgr.handleObserveMessage(path, coapMsg)
+
+	mockConv.AssertCalled(t, "CoAPToMessage", coapMsg)
+
+	select {
+	case outMsg := <-mgr.MessageChan():
+		require.NotNil(t, outMsg)
+		outPayload, err := outMsg.AsBytes()
+		require.NoError(t, err)
+		assert.Equal(t, "converted payload", string(outPayload))
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for message on channel")
+	}
+}
+
+func TestManager_HandleObserveMessage_ConverterError(t *testing.T) {
+	mgr, _, mockConv := newTestManager(t, Config{})
+	defer mgr.Close()
+
+	path := "/test/resource"
+	coapMsg := pool.AcquireMessage(context.Background())
+	defer pool.ReleaseMessage(coapMsg)
+	coapMsg.SetCode(codes.Content)
+
+	mockConv.On("CoAPToMessage", coapMsg).Return(nil, errors.New("converter failed"))
+
+	mockUDPConn := new(MockUDPClientConn)
+	mockUDPConn.On("Close").Return(nil).Maybe()
+	connWrapper := connection.NewConnectionWrapper(mockUDPConn, "udp", "localhost:5683", nil, service.MockLogger())
+	subCtx, cancelSub := context.WithCancel(context.Background())
+	defer cancelSub()
+	sub := &Subscription{path: path, conn: connWrapper, circuit: NewCircuitBreaker(DefaultCircuitConfig()), cancel: cancelSub, healthy: 1}
+	mgr.subscriptions[path] = sub
+
+	mgr.handleObserveMessage(path, coapMsg)
+
+	mockConv.AssertCalled(t, "CoAPToMessage", coapMsg)
+	assert.Len(t, mgr.MessageChan(), 0, "Message channel should be empty after converter error")
+}
+
+
+func TestManager_PerformObserve_UDPSuccess(t *testing.T) {
+	defaultConfig := Config{
+		ObservePaths:   []string{"/test"},
+		ObserveTimeout: 5 * time.Second,
+		RetryPolicy:    RetryPolicy{MaxRetries: 1, InitialInterval: 10 * time.Millisecond},
+		CircuitBreaker: DefaultCircuitConfig(),
+	}
+	mgr, mockConnMgr, mockConv := newTestManager(t, defaultConfig)
+	defer mgr.Close() // This will cancel the manager's context
+
+	mockUDP := new(MockUDPClientConn)
+	mockConnWrapperActual := NewMockConnectionWrapper(mockUDP, "udp", "localhost:5683")
+
+	// Use connection.ConnectionWrapper for the manager, but our MockConnectionWrapper for assertions/control
+	connWrapperForMgr := &connection.ConnectionWrapper // The real one, wrapping our mock CoAP conn
+	connWrapperForMgr = connection.NewConnectionWrapper(mockUDP, "udp", "localhost:5683", func() {}, service.MockLogger())
+
+
+	subCtx, subCancel := context.WithCancel(mgr.ctx) // Derive from manager's context
+	// defer subCancel() // subCancel will be called by performObserve's defer or by the test explicitly
+
+	sub := &Subscription{
+		path:    "/test",
+		conn:    connWrapperForMgr,
+		circuit: NewCircuitBreaker(defaultConfig.CircuitBreaker),
+		cancel:  subCancel, // This cancel is for the subscription's own context passed to observeWithRetry
+		healthy: 1,
+	}
+
+	token, _ := message.GetToken()
+	notificationPayload := "udp notification"
+
+	// Configure mock Observe for UDP
+	mockUDP.observeFunc = func(ctx context.Context, path string, observeFunc func(notification *message.Message), opts ...options.Option) (message.Token, error) {
+		assert.Equal(t, "/test", path)
+
+		// Simulate receiving a notification
+		go func() {
+			time.Sleep(50 * time.Millisecond) // Short delay
+			notif := pool.AcquireMessage(ctx) // Use the observe context
+			defer pool.ReleaseMessage(notif)
+			notif.SetCode(codes.Content)
+			notif.SetToken(token)
+			notif.SetBody(strings.NewReader(notificationPayload))
+			notif.SetObserve(1)
+			observeFunc(notif)
+
+			// Simulate observation end by cancelling the context after a notification
+			// In real CoAP, this might be due to server stopping observation or client cancelling
+			// For this test, we can simulate it to make performObserve return.
+			subCancel() // This will cause performObserve's <-observeCtx.Done() to unblock
+		}()
+		return token, nil
+	}
+
+	mockConv.On("CoAPToMessage", mock.AnythingOfTypeArgument("*message.Message")).Run(func(args mock.Arguments) {
+		msg := args.Get(0).(*message.Message)
+		payload, _ := msg.Body().Read(make([]byte, 100)) // Simplified read
+		msg.Body().Seek(0,0) // Reset seeker
+		assert.Contains(t, string(payload), notificationPayload)
+	}).Return(service.NewMessage([]byte(notificationPayload)), nil)
+
+
+	err := mgr.performObserve(subCtx, sub) // Pass the subscription's cancellable context
+	require.NoError(t, err, "performObserve should succeed")
+
+	// Check if message was received
+	select {
+	case msg := <-mgr.MessageChan():
+		payload, _ := msg.AsBytes()
+		assert.Equal(t, notificationPayload, string(payload))
+	case <-time.After(200 * time.Millisecond):
+		t.Error("Timeout waiting for notification message")
+	}
+
+	mockConv.AssertExpectations(t)
+}
+
+
+func TestManager_PerformObserve_TCPSuccess(t *testing.T) {
+    defaultConfig := Config{
+        ObservePaths:   []string{"/tcp_test"},
+        ObserveTimeout: 5 * time.Second,
+        RetryPolicy:    RetryPolicy{MaxRetries: 1, InitialInterval: 10 * time.Millisecond},
+        CircuitBreaker: DefaultCircuitConfig(),
+    }
+    mgr, _, mockConv := newTestManager(t, defaultConfig)
+    defer mgr.Close()
+
+    mockTCP := new(MockTCPClientConn)
+	mockTCPObs := new(MockTCPObservation)
+
+    connWrapperForMgr := connection.NewConnectionWrapper(mockTCP, "tcp", "localhost:5684", func() {}, service.MockLogger())
+
+    subCtx, subCancel := context.WithCancel(mgr.ctx)
+    // defer subCancel() // subCancel is called by performObserve or explicitly
+
+    sub := &Subscription{
+        path:    "/tcp_test",
+        conn:    connWrapperForMgr,
+        circuit: NewCircuitBreaker(defaultConfig.CircuitBreaker),
+        cancel:  subCancel,
+        healthy: 1,
+    }
+
+    token, _ := message.GetToken()
+	mockTCPObs.token = token
+    notificationPayload := "tcp notification"
+
+    // Configure mock Observe for TCP
+	mockTCP.observeFunc = func(ctx context.Context, path string, observeFunc func(notification *message.Message), opts ...options.Option) (*tcpClient.Observation, error) {
+        assert.Equal(t, "/tcp_test", path)
+
+        // Simulate receiving a notification
+        go func() {
+            time.Sleep(50 * time.Millisecond)
+            notif := pool.AcquireMessage(ctx)
+            defer pool.ReleaseMessage(notif)
+            notif.SetCode(codes.Content)
+            notif.SetToken(token)
+            notif.SetBody(strings.NewReader(notificationPayload))
+            notif.SetObserve(1)
+            observeFunc(notif)
+
+			// Simulate observation ending
+			subCancel()
+        }()
+        return mockTCPObs, nil
+    }
+	mockTCPObs.On("Token").Return(token)
+	mockTCPObs.On("Cancel", mock.Anything).Return(nil).Once() // Expect Cancel to be called
+
+    mockConv.On("CoAPToMessage", mock.AnythingOfTypeArgument("*message.Message")).Return(service.NewMessage([]byte(notificationPayload)), nil)
+
+    err := mgr.performObserve(subCtx, sub)
+    require.NoError(t, err, "performObserve for TCP should succeed")
+
+    select {
+    case msg := <-mgr.MessageChan():
+        payload, _ := msg.AsBytes()
+        assert.Equal(t, notificationPayload, string(payload))
+    case <-time.After(200 * time.Millisecond):
+        t.Error("Timeout waiting for TCP notification message")
+    }
+
+    mockConv.AssertExpectations(t)
+	mockTCPObs.AssertCalled(t, "Cancel", mock.Anything)
+}
+
+
+func TestManager_PerformObserve_ObserveErrorUDP(t *testing.T) {
+	defaultConfig := Config{ObserveTimeout: 100 * time.Millisecond}
+	mgr, _, _ := newTestManager(t, defaultConfig)
+	defer mgr.Close()
+
+	mockUDP := new(MockUDPClientConn)
+	connWrapperForMgr := connection.NewConnectionWrapper(mockUDP, "udp", "localhost:5683", func() {}, service.MockLogger())
+
+	subCtx, subCancel := context.WithCancel(mgr.ctx)
+	defer subCancel()
+	sub := &Subscription{path: "/test_err", conn: connWrapperForMgr, circuit: NewCircuitBreaker(DefaultCircuitConfig()), cancel: subCancel}
+
+	expectedErr := errors.New("udp observe failed")
+	mockUDP.observeFunc = func(ctx context.Context, path string, observeFunc func(notification *message.Message), opts ...options.Option) (message.Token, error) {
+		return nil, expectedErr
+	}
+
+	err := mgr.performObserve(subCtx, sub)
+	require.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestManager_PerformObserve_ContextCancelled(t *testing.T) {
+	defaultConfig := Config{ObserveTimeout: 5 * time.Second} // Long timeout
+	mgr, _, _ := newTestManager(t, defaultConfig)
+	// Do not defer mgr.Close() here, as we want to control sub-context cancellation manually for the test
+
+	mockUDP := new(MockUDPClientConn)
+	connWrapperForMgr := connection.NewConnectionWrapper(mockUDP, "udp", "localhost:5683", func() {}, service.MockLogger())
+
+	managerCtx, managerCancel := context.WithCancel(context.Background()) // Independent manager ctx for this test
+	mgr.ctx = managerCtx // Override manager's context
+
+	subCtx, subCancel := context.WithCancel(managerCtx) // Sub-context for performObserve
+
+	sub := &Subscription{path: "/test_cancel", conn: connWrapperForMgr, circuit: NewCircuitBreaker(DefaultCircuitConfig()), cancel: subCancel}
+
+	waitGroup := sync.WaitGroup{}
+	waitGroup.Add(1)
+
+	mockUDP.observeFunc = func(ctx context.Context, path string, observeFunc func(notification *message.Message), opts ...options.Option) (message.Token, error) {
+		// Simulate blocking until context is cancelled
+		go func() {
+			defer waitGroup.Done()
+			<-ctx.Done() // Wait for cancellation
+		}()
+		return message.Token("token"), nil // Successfully started observation
+	}
+
+	// Cancel the subCtx *before* calling performObserve to simulate immediate cancellation
+	subCancel()
+
+	err := mgr.performObserve(subCtx, sub)
+	require.Error(t, err, "Error should be context.Canceled or DeadlineExceeded if timeout was also very short")
+	assert.True(t, errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded), "Expected context.Canceled or DeadlineExceeded")
+
+	waitGroup.Wait() // Ensure the observeFunc goroutine exits
+	managerCancel() // Clean up manager context
+}
+
+func TestManager_ObserveWithRetry_RetriesAndSucceeds(t *testing.T) {
+	retryAttempts := 0
+	maxRetries := 2 // Manager will try original + 2 retries = 3 attempts
+	expectedObserveCalls := maxRetries + 1
+
+	config := Config{
+		ObservePaths:     []string{"/test"},
+		RetryPolicy:      RetryPolicy{MaxRetries: maxRetries, InitialInterval: 5 * time.Millisecond, MaxInterval: 20 * time.Millisecond, Multiplier: 1.5},
+		CircuitBreaker:   DefaultCircuitConfig(), // Keep CB simple for this test
+		BufferSize:       10,
+		ObserveTimeout:   100 * time.Millisecond,
+		ResubscribeDelay: 50 * time.Millisecond,
+	}
+	mgr, mockConnMgr, mockConv := newTestManager(t, config)
+	// No defer mgr.Close() yet, we want to control lifecycle
+
+	mockUDP := new(MockUDPClientConn)
+	mockConnWrapperForMgr := connection.NewConnectionWrapper(mockUDP, "udp", "localhost:5683", func() {}, service.MockLogger())
+
+	mockConnMgr.On("Get", mock.Anything).Return(mockConnWrapperForMgr, nil)
+	mockConnMgr.On("Put", mockConnWrapperForMgr).Return()
+	mockConnMgr.On("Close").Return(nil).Maybe() // For mgr.Close()
+
+	notificationPayload := "udp notification after retries"
+	observeCallCount := 0
+
+	mockUDP.observeFunc = func(ctx context.Context, path string, observeFunc func(notification *message.Message), opts ...options.Option) (message.Token, error) {
+		observeCallCount++
+		if observeCallCount <= maxRetries { // Fail for initial attempts
+			retryAttempts++
+			return nil, errors.New(fmt.Sprintf("simulated observe error attempt %d", observeCallCount))
+		}
+		// Succeed on the last attempt
+		token, _ := message.GetToken()
+		go func() { // Simulate async notification
+			time.Sleep(10 * time.Millisecond)
+			notif := pool.AcquireMessage(ctx)
+			defer pool.ReleaseMessage(notif)
+			notif.SetCode(codes.Content)
+			notif.SetToken(token)
+			notif.SetBody(strings.NewReader(notificationPayload))
+			notif.SetObserve(1)
+			observeFunc(notif)
+			// No explicit cancel here, let performObserve timeout or main test context cancel
+		}()
+		return token, nil
+	}
+
+	mockConv.On("CoAPToMessage", mock.AnythingOfTypeArgument("*message.Message")).Return(service.NewMessage([]byte(notificationPayload)), nil).Maybe()
+
+	// Start the manager's subscription process
+	err := mgr.Subscribe("/test")
+	require.NoError(t, err)
+
+	// Wait for the message to arrive or timeout
+	select {
+	case msg := <-mgr.MessageChan():
+		payload, _ := msg.AsBytes()
+		assert.Equal(t, notificationPayload, string(payload))
+	case <-time.After(500 * time.Millisecond): // Increased timeout for retries
+		t.Fatal("Timeout waiting for message after retries")
+	}
+
+	mgr.Close() // Close manager to stop observation goroutines
+
+	assert.Equal(t, maxRetries, retryAttempts, "Should have retried specified number of times")
+	assert.Equal(t, expectedObserveCalls, observeCallCount, "Observe method should be called expected number of times")
+
+	// Check subscription health (should be healthy after success)
+	sub := mgr.getSubscription("/test")
+	require.NotNil(t, sub)
+	assert.True(t, sub.circuit.IsHealthy(), "Circuit breaker should be healthy")
+	assert.Equal(t, int32(0), sub.retryCount, "Subscription retry count should be reset after success")
+}
+
+
+func TestManager_ObserveWithRetry_MaxRetriesExceeded(t *testing.T) {
+	maxRetries := 2
+	expectedObserveCalls := maxRetries + 1 // Initial attempt + maxRetries
+
+	config := Config{
+		ObservePaths:     []string{"/test_max_retry"},
+		RetryPolicy:      RetryPolicy{MaxRetries: maxRetries, InitialInterval: 5 * time.Millisecond, MaxInterval: 10 * time.Millisecond, Multiplier: 1.2},
+		CircuitBreaker:   DefaultCircuitConfig(),
+		BufferSize:       10,
+		ObserveTimeout:   50 * time.Millisecond,
+	}
+	mgr, mockConnMgr, _ := newTestManager(t, config)
+	// No defer mgr.Close() yet
+
+	mockUDP := new(MockUDPClientConn)
+	mockConnWrapperForMgr := connection.NewConnectionWrapper(mockUDP, "udp", "localhost:5683", func() {}, service.MockLogger())
+
+	mockConnMgr.On("Get", mock.Anything).Return(mockConnWrapperForMgr, nil)
+	mockConnMgr.On("Put", mockConnWrapperForMgr).Return()
+	mockConnMgr.On("Close").Return(nil).Maybe()
+
+
+	observeCallCount := 0
+	mockUDP.observeFunc = func(ctx context.Context, path string, observeFunc func(notification *message.Message), opts ...options.Option) (message.Token, error) {
+		observeCallCount++
+		return nil, errors.New(fmt.Sprintf("persistent observe error %d", observeCallCount))
+	}
+
+	err := mgr.Subscribe("/test_max_retry")
+	require.NoError(t, err)
+
+	// Wait long enough for all retries to exhaust
+	time.Sleep(100 * time.Millisecond)
+
+	mgr.Close()
+
+	assert.Equal(t, expectedObserveCalls, observeCallCount, "Observe method should be called for initial + all retries")
+
+	sub := mgr.getSubscription("/test_max_retry")
+	require.NotNil(t, sub)
+	assert.False(t, sub.circuit.IsHealthy(), "Circuit breaker should be unhealthy (or at least not explicitly healthy)")
+	assert.Equal(t, int32(expectedObserveCalls), sub.retryCount, "Subscription retry count should reflect all attempts")
+	assert.Equal(t, int32(0), sub.healthy, "Subscription should be marked as unhealthy")
+}
+
+func TestManager_ObserveWithRetry_CircuitBreaker(t *testing.T) {
+	cbFailures := 2
+	cbResetInterval := 50 * time.Millisecond
+	config := Config{
+		ObservePaths:   []string{"/test_cb"},
+		RetryPolicy:    RetryPolicy{MaxRetries: 5, InitialInterval: 5 * time.Millisecond}, // Allow enough retries
+		CircuitBreaker: CircuitConfig{Enabled: true, FailureThreshold: uint32(cbFailures), ResetInterval: cbResetInterval, OpenStateDelay: cbResetInterval},
+		BufferSize:     10,
+		ObserveTimeout: 30 * time.Millisecond,
+	}
+	mgr, mockConnMgr, mockConv := newTestManager(t, config)
+
+	mockUDP := new(MockUDPClientConn)
+	mockConnWrapperForMgr := connection.NewConnectionWrapper(mockUDP, "udp", "localhost:5683", func() {}, service.MockLogger())
+
+	mockConnMgr.On("Get", mock.Anything).Return(mockConnWrapperForMgr, nil)
+	mockConnMgr.On("Put", mockConnWrapperForMgr).Return()
+	mockConnMgr.On("Close").Return(nil).Maybe()
+
+	observeCallCount := 0
+	notificationPayload := "cb notification"
+	var failObserve bool = true // Start by failing
+
+	mockUDP.observeFunc = func(ctx context.Context, path string, observeFunc func(notification *message.Message), opts ...options.Option) (message.Token, error) {
+		observeCallCount++
+		if failObserve {
+			return nil, errors.New(fmt.Sprintf("cb observe error %d", observeCallCount))
+		}
+		// Succeed after circuit breaker has reset
+		token, _ := message.GetToken()
+		go func() {
+			time.Sleep(5 * time.Millisecond)
+			notif := pool.AcquireMessage(ctx); defer pool.ReleaseMessage(notif)
+			notif.SetCode(codes.Content); notif.SetToken(token); notif.SetBody(strings.NewReader(notificationPayload)); notif.SetObserve(1)
+			observeFunc(notif)
+		}()
+		return token, nil
+	}
+	mockConv.On("CoAPToMessage", mock.AnythingOfTypeArgument("*message.Message")).Return(service.NewMessage([]byte(notificationPayload)), nil).Maybe()
+
+
+	err := mgr.Subscribe("/test_cb")
+	require.NoError(t, err)
+
+	// Wait for initial failures to open the circuit
+	time.Sleep(time.Duration(cbFailures+1) * (config.RetryPolicy.InitialInterval + config.ObserveTimeout) + 10*time.Millisecond) // Ensure enough time for failures
+
+	sub := mgr.getSubscription("/test_cb")
+	require.NotNil(t, sub)
+	assert.Equal(t, CircuitStateOpen, sub.circuit.State(), "Circuit should be open after enough failures")
+	callsWhileOpen := observeCallCount // Store calls before circuit reset
+
+	// Wait for circuit breaker to reset and potentially one retry attempt in half-open
+	time.Sleep(cbResetInterval + config.RetryPolicy.InitialInterval + 10*time.Millisecond)
+
+	failObserve = false // Now allow observe to succeed
+
+	// Wait for successful notification or timeout
+	select {
+	case <-mgr.MessageChan():
+		// Message received
+	case <-time.After(cbResetInterval + config.ObserveTimeout + 50*time.Millisecond): // Wait for recovery attempt
+		t.Fatal("Timeout waiting for message after circuit breaker reset")
+	}
+
+	mgr.Close()
+
+	assert.True(t, observeCallCount > callsWhileOpen, "Observe should have been called again after circuit reset")
+	assert.True(t, sub.circuit.IsHealthy(), "Circuit breaker should be healthy after success")
+}

--- a/pkg/output/coap_output_plugin_test.go
+++ b/pkg/output/coap_output_plugin_test.go
@@ -1,0 +1,705 @@
+package output
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/plgd-dev/go-coap/v3/message"
+	"github.com/plgd-dev/go-coap/v3/message/codes"
+	"github.com/plgd-dev/go-coap/v3/message/pool"
+	"github.com/plgd-dev/go-coap/v3/options"
+	coapNet "github.com/plgd-dev/go-coap/v3/net"
+	udpClient "github.com/plgd-dev/go-coap/v3/udp/client"
+	tcpClient "github.com/plgd-dev/go-coap/v3/tcp/client"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/twinfer/benthos-coap-plugin/pkg/connection"
+	"github.com/twinfer/benthos-coap-plugin/pkg/converter"
+)
+
+// --- Mocks (can be shared or adapted from observer tests) ---
+
+// MockConnectionWrapper (assuming it's defined as in observer_test or in a shared test util)
+type MockConnectionWrapper struct {
+	mock.Mock
+	conn      interface{}
+	protocol  string
+	endpoint  string
+	closed    bool
+	closeChan chan struct{}
+}
+
+func NewMockConnectionWrapper(conn interface{}, protocol, endpoint string) *MockConnectionWrapper {
+	return &MockConnectionWrapper{
+		conn:      conn,
+		protocol:  protocol,
+		endpoint:  endpoint,
+		closeChan: make(chan struct{}),
+	}
+}
+func (m *MockConnectionWrapper) Connection() interface{} { return m.conn }
+func (m *MockConnectionWrapper) Protocol() string      { return m.protocol }
+func (m *MockConnectionWrapper) Endpoint() string      { return m.endpoint }
+func (m *MockConnectionWrapper) Close() error {
+	if m.closed {
+		return errors.New("already closed")
+	}
+	m.closed = true
+	close(m.closeChan)
+	// Ensure we return an error if one is expected by the mock setup for Close()
+	// If no specific error is set for Close(), return nil by default for success.
+	args := m.Called()
+	return args.Error(0)
+}
+func (m *MockConnectionWrapper) Closed() <-chan struct{} { return m.closeChan }
+func (m *MockConnectionWrapper) Healthy() bool           { return !m.closed }
+
+
+// MockConnectionManager
+type MockConnectionManager struct {
+	mock.Mock
+}
+
+func (m *MockConnectionManager) Get(ctx context.Context) (*connection.ConnectionWrapper, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*connection.ConnectionWrapper), args.Error(1)
+}
+func (m *MockConnectionManager) Put(conn *connection.ConnectionWrapper) { m.Called(conn) }
+func (m *MockConnectionManager) Config() connection.Config {
+	args := m.Called()
+	return args.Get(0).(connection.Config)
+}
+func (m *MockConnectionManager) Close() error { return m.Called().Error(0) }
+
+// MockConverter
+type MockConverter struct {
+	mock.Mock
+}
+func (m *MockConverter) CoAPToMessage(coapMsg *message.Message) (*service.Message, error) {
+	args := m.Called(coapMsg)
+	if args.Get(0) == nil { return nil, args.Error(1) }
+	return args.Get(0).(*service.Message), args.Error(1)
+}
+func (m *MockConverter) MessageToCoAP(msg *service.Message) (*message.Message, error) {
+	args := m.Called(msg)
+	if args.Get(0) == nil { return nil, args.Error(1) }
+	return args.Get(0).(*message.Message), args.Error(1)
+}
+
+
+func TestWriteWithRetry_ConnManagerGetError(t *testing.T) {
+	outputConf := OutputConfig{DefaultPath: "/default"}
+	out, mockConnMgr, _ := newTestOutput(t, outputConf)
+
+	expectedErr := errors.New("conn manager Get failed")
+	mockConnMgr.On("Get", mock.Anything).Return(nil, expectedErr)
+
+	benthosMsg := service.NewMessage([]byte("test"))
+	err := out.Write(context.Background(), benthosMsg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), expectedErr.Error())
+	mockConnMgr.AssertCalled(t, "Get", mock.Anything)
+}
+
+func TestWriteWithRetry_ConverterMessageToCoAPError(t *testing.T) {
+	outputConf := OutputConfig{DefaultPath: "/default"}
+	out, mockConnMgr, mockConv := newTestOutput(t, outputConf)
+
+	mockUDP := new(MockUDPClientConn) // Real conn not strictly needed as converter fails first
+	mockReturnedConnWrapper := connection.NewConnectionWrapper(mockUDP, "udp", "localhost:5683", func(){}, service.MockLogger())
+
+	mockConnMgr.On("Get", mock.Anything).Return(mockReturnedConnWrapper, nil)
+	mockConnMgr.On("Put", mockReturnedConnWrapper).Return() // Expect Put because Get succeeded
+
+	expectedErr := errors.New("converter MessageToCoAP failed")
+	benthosMsg := service.NewMessage([]byte("test"))
+	mockConv.On("MessageToCoAP", benthosMsg).Return(nil, expectedErr)
+
+	err := out.Write(context.Background(), benthosMsg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), expectedErr.Error())
+	mockConnMgr.AssertCalled(t, "Get", mock.Anything)
+	mockConnMgr.AssertCalled(t, "Put", mockReturnedConnWrapper)
+	mockConv.AssertCalled(t, "MessageToCoAP", benthosMsg)
+}
+
+
+// MockUDPClientConn
+type MockUDPClientConn struct {
+	mock.Mock
+	udpClient.Conn // Embed for interface fulfillment
+	doFunc func(ctx context.Context, req *message.Message) (*message.Message, error)
+}
+func (m *MockUDPClientConn) Do(ctx context.Context, req *message.Message) (*message.Message, error) {
+	if m.doFunc != nil { return m.doFunc(ctx, req) }
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil { return nil, args.Error(1) }
+	return args.Get(0).(*message.Message), args.Error(1)
+}
+func (m *MockUDPClientConn) Close() error { return m.Called().Error(0) }
+func (m *MockUDPClientConn) Ping(ctx context.Context) error { return m.Called(ctx).Error(0) }
+func (m *MockUDPClientConn) RemoteAddr() coapNet.Addr { return nil }
+func (m *MockUDPClientConn) Context() context.Context { return context.Background() }
+
+
+// MockTCPClientConn
+type MockTCPClientConn struct {
+	mock.Mock
+	tcpClient.Conn // Embed for interface fulfillment
+	doFunc func(ctx context.Context, req *message.Message) (*message.Message, error)
+}
+func (m *MockTCPClientConn) Do(ctx context.Context, req *message.Message) (*message.Message, error) {
+	if m.doFunc != nil { return m.doFunc(ctx, req) }
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil { return nil, args.Error(1) }
+	return args.Get(0).(*message.Message), args.Error(1)
+}
+func (m *MockTCPClientConn) Close() error { return m.Called().Error(0) }
+func (m *MockTCPClientConn) Ping(ctx context.Context) error { return m.Called(ctx).Error(0) }
+func (m *MockTCPClientConn) RemoteAddr() coapNet.Addr { return nil }
+func (m *MockTCPClientConn) Context() context.Context { return context.Background() }
+
+
+// --- Test Suite Setup ---
+func newTestOutput(t *testing.T, outputConf OutputConfig) (*Output, *MockConnectionManager, *MockConverter) {
+	logger := service.MockLogger()
+	mockConnMgr := new(MockConnectionManager)
+	mockConv := new(MockConverter)
+
+	// Provide default connection manager config
+	connMgrConf := connection.Config{
+		Endpoints: outputConf.Endpoints,
+		Protocol:  outputConf.Protocol,
+	}
+	mockConnMgr.On("Config").Return(connMgrConf).Maybe()
+
+	// Create the output using a helper that mirrors `newCoAPOutput` but with mocks
+	out := &Output{
+		connManager: mockConnMgr,
+		converter:   mockConv,
+		config:      outputConf,
+		logger:      logger,
+		metrics: &Metrics{ // Initialize metrics to avoid nil pointer dereferences
+			MessagesSent:    service.MockMetricCounter(),
+			MessagesFailed:  service.MockMetricCounter(),
+			RequestsTotal:   service.MockMetricCounter(),
+			RequestsSuccess: service.MockMetricCounter(),
+			RequestsTimeout: service.MockMetricCounter(),
+			RetriesTotal:    service.MockMetricCounter(),
+			ConnectionsUsed: service.MockMetricCounter(),
+		},
+	}
+	return out, mockConnMgr, mockConv
+}
+
+
+// --- Tests ---
+
+func TestSendCoAPMessage_Delegation(t *testing.T) {
+	defaultOutputConf := OutputConfig{
+		Protocol: "udp", // Default, will be overridden by mock conn wrapper
+		RequestOptions: RequestOptions{Timeout: 5 * time.Second},
+	}
+
+	tests := []struct {
+		name         string
+		protocol     string
+		connClient   interface{} // *MockUDPClientConn or *MockTCPClientConn
+		expectUDPCall bool
+		expectTCPCall bool
+		expectedError string
+	}{
+		{
+			name: "UDP protocol", protocol: "udp", connClient: new(MockUDPClientConn),
+			expectUDPCall: true, expectTCPCall: false,
+		},
+		{
+			name: "DTLS protocol (uses UDP conn)", protocol: "udp-dtls", connClient: new(MockUDPClientConn),
+			expectUDPCall: true, expectTCPCall: false,
+		},
+		{
+			name: "TCP protocol", protocol: "tcp", connClient: new(MockTCPClientConn),
+			expectUDPCall: false, expectTCPCall: true,
+		},
+		{
+			name: "TLS protocol (uses TCP conn)", protocol: "tcp-tls", connClient: new(MockTCPClientConn),
+			expectUDPCall: false, expectTCPCall: true,
+		},
+		{
+			name: "Unsupported protocol in wrapper", protocol: "http", connClient: new(MockUDPClientConn), // connClient type won't matter here
+			expectedError: "unsupported connection type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, _, mockConv := newTestOutput(t, defaultOutputConf)
+
+			mockConnWrapper := NewMockConnectionWrapper(tt.connClient, tt.protocol, "localhost:1234")
+
+			coapMsg := pool.AcquireMessage(context.Background())
+			defer pool.ReleaseMessage(coapMsg)
+			coapMsg.SetCode(codes.POST)
+			coapMsg.SetToken(message.Token("test"))
+			// mockConv.On("MessageToCoAP", mock.Anything).Return(coapMsg, nil) // Not needed for sendCoAPMessage directly
+
+			if tt.expectUDPCall {
+				mockUDP := tt.connClient.(*MockUDPClientConn)
+				// Mock the Do func to return success immediately
+				mockUDP.doFunc = func(ctx context.Context, req *message.Message) (*message.Message, error) {
+					resp := pool.AcquireMessage(ctx)
+					resp.SetCode(codes.Changed)
+					return resp, nil
+				}
+			}
+			if tt.expectTCPCall {
+				mockTCP := tt.connClient.(*MockTCPClientConn)
+				mockTCP.doFunc = func(ctx context.Context, req *message.Message) (*message.Message, error) {
+					resp := pool.AcquireMessage(ctx)
+					resp.SetCode(codes.Changed)
+					return resp, nil
+				}
+			}
+
+			err := out.sendCoAPMessage(context.Background(), (*connection.ConnectionWrapper)(mockConnWrapper), coapMsg, "/testpath")
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+
+func TestOutput_Close(t *testing.T) {
+	out, mockConnMgr, _ := newTestOutput(t, OutputConfig{})
+
+	mockConnMgr.On("Close").Return(nil).Once()
+
+	err := out.Close(context.Background())
+	assert.NoError(t, err)
+	mockConnMgr.AssertCalled(t, "Close")
+
+	// Test close error
+	expectedErr := errors.New("conn manager close failed")
+	mockConnMgrError := new(MockConnectionManager) // New mock for error case
+	mockConnMgrError.On("Config").Return(connection.Config{})
+	mockConnMgrError.On("Close").Return(expectedErr).Once()
+
+	outError := &Output{ // Create new output with erroring mock
+		connManager: mockConnMgrError,
+		logger:      service.MockLogger(),
+		metrics:     &Metrics{},
+	}
+	err = outError.Close(context.Background())
+	assert.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+	mockConnMgrError.AssertCalled(t, "Close")
+}
+
+func TestSendTCPMessage_ErrorCases(t *testing.T) {
+	out, _, _ := newTestOutput(t, OutputConfig{RequestOptions: RequestOptions{Timeout: 20 * time.Millisecond}}) // Short timeout
+	mockTCP := new(MockTCPClientConn)
+	reqMsg := pool.AcquireMessage(context.Background()); defer pool.ReleaseMessage(reqMsg)
+	reqMsg.SetCode(codes.POST)
+
+	tests := []struct{
+		name string
+		setupMock func()
+		expectedErrorContains string
+	}{
+		{
+			name: "Do returns error",
+			setupMock: func() {
+				mockTCP.doFunc = func(ctx context.Context, req *message.Message) (*message.Message, error) {
+					return nil, errors.New("tcp do failed")
+				}
+			},
+			expectedErrorContains: "tcp do failed",
+		},
+		{
+			name: "Non-2xx response code",
+			setupMock: func() {
+				mockTCP.doFunc = func(ctx context.Context, req *message.Message) (*message.Message, error) {
+					resp := pool.AcquireMessage(ctx)
+					resp.SetCode(codes.BadGateway)
+					return resp, nil
+				}
+			},
+			expectedErrorContains: "returned error code 5.02",
+		},
+		{
+			name: "Request timeout",
+			setupMock: func() {
+				mockTCP.doFunc = func(ctx context.Context, req *message.Message) (*message.Message, error) {
+					time.Sleep(50 * time.Millisecond) // Longer than timeout
+					return nil, errors.New("should have timed out")
+				}
+			},
+			expectedErrorContains: "timed out",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T){
+			tt.setupMock()
+			err := out.sendTCPMessage(context.Background(), mockTCP, reqMsg, "ep", "/p", "tok")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErrorContains)
+		})
+	}
+}
+
+
+func TestSendUDPMessage_Success(t *testing.T) {
+	out, _, _ := newTestOutput(t, OutputConfig{RequestOptions: RequestOptions{Timeout: 100 * time.Millisecond}})
+	mockUDP := new(MockUDPClientConn)
+
+	reqMsg := pool.AcquireMessage(context.Background()); defer pool.ReleaseMessage(reqMsg)
+	reqMsg.SetCode(codes.POST) // This code is on the message from converter, send*Message will use POST by default for the actual request.
+	reqMsg.SetToken(message.Token("token123"))
+	reqMsg.SetPathString("/testpath") // Path set by converter
+	reqMsg.SetPayload([]byte("test payload"))
+	reqMsg.SetType(message.Confirmable)
+	err := reqMsg.SetOptionUint32(message.ContentFormat, message.TextPlain) // Option from converter
+	require.NoError(t, err)
+
+
+	mockUDP.doFunc = func(ctx context.Context, actualReq *message.Message) (*message.Message, error) {
+		// Verify the message sent by sendUDPMessage via conn.Do()
+		assert.Equal(t, codes.POST, actualReq.Code(), "Request code should be POST (default in sendUDPMessage)")
+		assert.Equal(t, reqMsg.Token(), actualReq.Token(), "Token should match")
+
+		path, pErr := actualReq.Path()
+		require.NoError(t, pErr)
+		assert.Equal(t, "testpath", path, "Path should match")
+
+		assert.Equal(t, reqMsg.Payload(), actualReq.Payload(), "Payload should match")
+		assert.Equal(t, reqMsg.Type(), actualReq.Type(), "Message type should match")
+
+		cf, cfErr := actualReq.Options().GetUint32(message.ContentFormat)
+		require.NoError(t, cfErr, "ContentFormat option should be present")
+		assert.Equal(t, uint32(message.TextPlain), cf, "ContentFormat should match")
+
+		resp := pool.AcquireMessage(ctx)
+		resp.SetCode(codes.Created)
+		return resp, nil
+	}
+
+	err := out.sendUDPMessage(context.Background(), mockUDP, reqMsg, "endpoint", "/test", "token")
+	require.NoError(t, err)
+}
+
+func TestSendTCPMessage_Success(t *testing.T) {
+	out, _, _ := newTestOutput(t, OutputConfig{RequestOptions: RequestOptions{Timeout: 100 * time.Millisecond}})
+	mockTCP := new(MockTCPClientConn)
+
+	reqMsg := pool.AcquireMessage(context.Background()); defer pool.ReleaseMessage(reqMsg)
+	reqMsg.SetCode(codes.PUT) // This code is on the message from converter. sendTCPMessage will use POST.
+	reqMsg.SetToken(message.Token("tokenTCP123"))
+	reqMsg.SetPathString("/tcp_resource_path")
+	reqMsg.SetPayload([]byte("tcp test payload"))
+	reqMsg.SetType(message.NonConfirmable)
+	err := reqMsg.SetOptionUint32(message.ContentFormat, message.AppJSON)
+	require.NoError(t, err)
+
+
+	mockTCP.doFunc = func(ctx context.Context, actualReq *message.Message) (*message.Message, error) {
+		assert.Equal(t, codes.POST, actualReq.Code(), "Request code should be POST (default in sendTCPMessage)")
+		assert.Equal(t, reqMsg.Token(), actualReq.Token(), "Token should match")
+
+		path, pErr := actualReq.Path()
+		require.NoError(t, pErr)
+		assert.Equal(t, "tcp_resource_path", path, "Path should match")
+
+		assert.Equal(t, reqMsg.Payload(), actualReq.Payload(), "Payload should match")
+		assert.Equal(t, reqMsg.Type(), actualReq.Type(), "Message type should match")
+
+		cf, cfErr := actualReq.Options().GetUint32(message.ContentFormat)
+		require.NoError(t, cfErr, "ContentFormat option should be present")
+		assert.Equal(t, uint32(message.AppJSON), cf, "ContentFormat should match")
+
+		resp := pool.AcquireMessage(ctx)
+		resp.SetCode(codes.Changed)
+		return resp, nil
+	}
+
+	err := out.sendTCPMessage(context.Background(), mockTCP, reqMsg, "endpoint", "/tcp_resource", "tokenTCP")
+	require.NoError(t, err)
+}
+
+
+func TestSendUDPMessage_ErrorCases(t *testing.T) {
+	out, _, _ := newTestOutput(t, OutputConfig{RequestOptions: RequestOptions{Timeout: 20 * time.Millisecond}}) // Short timeout
+	mockUDP := new(MockUDPClientConn)
+	reqMsg := pool.AcquireMessage(context.Background()); defer pool.ReleaseMessage(reqMsg)
+	reqMsg.SetCode(codes.POST)
+
+	tests := []struct{
+		name string
+		setupMock func()
+		expectedErrorContains string
+	}{
+		{
+			name: "Do returns error",
+			setupMock: func() {
+				mockUDP.doFunc = func(ctx context.Context, req *message.Message) (*message.Message, error) {
+					return nil, errors.New("udp do failed")
+				}
+			},
+			expectedErrorContains: "udp do failed",
+		},
+		{
+			name: "Non-2xx response code",
+			setupMock: func() {
+				mockUDP.doFunc = func(ctx context.Context, req *message.Message) (*message.Message, error) {
+					resp := pool.AcquireMessage(ctx)
+					resp.SetCode(codes.NotFound)
+					return resp, nil
+				}
+			},
+			expectedErrorContains: "returned error code 4.04",
+		},
+		{
+			name: "Request timeout",
+			setupMock: func() {
+				mockUDP.doFunc = func(ctx context.Context, req *message.Message) (*message.Message, error) {
+					time.Sleep(50 * time.Millisecond) // Longer than timeout
+					return nil, errors.New("should have timed out") // This error shouldn't be returned if timeout works
+				}
+			},
+			expectedErrorContains: "timed out", // context.DeadlineExceeded.Error() is "context deadline exceeded"
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T){
+			tt.setupMock()
+			err := out.sendUDPMessage(context.Background(), mockUDP, reqMsg, "ep", "/p", "tok")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErrorContains)
+		})
+	}
+}
+
+
+func TestWriteWithRetry_RetriesAndSucceeds(t *testing.T) {
+	maxRetries := 2
+	outputConf := OutputConfig{
+		DefaultPath: "/default",
+		RetryPolicy: RetryPolicy{MaxRetries: maxRetries, InitialInterval: 5 * time.Millisecond, MaxInterval: 10 * time.Millisecond},
+		RequestOptions: RequestOptions{Timeout: 50*time.Millisecond, Confirmable: true},
+	}
+	out, mockConnMgr, mockConv := newTestOutput(t, outputConf)
+
+	mockUDP := new(MockUDPClientConn)
+	// Corrected: Use the actual connection.ConnectionWrapper for the manager to return
+	mockReturnedConnWrapper := connection.NewConnectionWrapper(mockUDP, "udp", "localhost:5683", func(){}, service.MockLogger())
+
+	mockConnMgr.On("Get", mock.Anything).Return(mockReturnedConnWrapper, nil)
+	mockConnMgr.On("Put", mockReturnedConnWrapper).Return() // Expect Put to be called with the same wrapper
+	mockConnMgr.On("Close").Return(nil).Maybe()
+
+
+	benthosMsg := service.NewMessage([]byte("test content"))
+	coapReqMsg := pool.AcquireMessage(context.Background()); defer pool.ReleaseMessage(coapReqMsg)
+	coapReqMsg.SetCode(codes.POST) // Default method
+	coapReqMsg.SetType(message.Confirmable) // From RequestOptions
+	coapReqMsg.SetPathString("/default")    // From DefaultPath
+	coapReqMsg.SetPayload([]byte("test content"))
+
+	mockConv.On("MessageToCoAP", benthosMsg).Return(coapReqMsg, nil)
+
+	sendAttempt := 0
+	mockUDP.doFunc = func(ctx context.Context, req *message.Message) (*message.Message, error) {
+		sendAttempt++
+		if sendAttempt <= maxRetries {
+			return nil, errors.New("simulated send error")
+		}
+		resp := pool.AcquireMessage(ctx)
+		resp.SetCode(codes.Changed)
+		return resp, nil
+	}
+
+	err := out.Write(context.Background(), benthosMsg)
+	require.NoError(t, err)
+	assert.Equal(t, maxRetries + 1, sendAttempt, "Should succeed after retries")
+
+	mockConnMgr.AssertCalled(t, "Get", mock.Anything)
+	mockConnMgr.AssertCalled(t, "Put", mockReturnedConnWrapper)
+	mockConv.AssertCalled(t, "MessageToCoAP", benthosMsg)
+}
+
+// TODO: Add more tests:
+// - TestWriteWithRetry_MaxRetriesExceeded
+// - TestWriteWithRetry_ContextCancelledDuringBackoff
+// - Test correct CoAP message construction in sendUDP/TCPMessage (options, token, type from converter)
+// - Test that path from metadata is used if present
+// - Test error from connManager.Get()
+// - Test error from converter.MessageToCoAP()
+// - Test Close() method of Output
+// - Test Health() method
+// - Test parsing of configs (if complex logic exists there)
+
+
+func TestWriteWithRetry_MaxRetriesExceeded(t *testing.T) {
+	maxRetries := 1 // Keep low for faster test
+	outputConf := OutputConfig{
+		DefaultPath: "/default",
+		RetryPolicy: RetryPolicy{MaxRetries: maxRetries, InitialInterval: 5 * time.Millisecond},
+		RequestOptions: RequestOptions{Timeout: 20*time.Millisecond, Confirmable: true},
+	}
+	out, mockConnMgr, mockConv := newTestOutput(t, outputConf)
+
+	mockUDP := new(MockUDPClientConn)
+	mockReturnedConnWrapper := connection.NewConnectionWrapper(mockUDP, "udp", "localhost:5683", func(){}, service.MockLogger())
+
+	// Setup mock calls
+	mockConnMgr.On("Get", mock.Anything).Return(mockReturnedConnWrapper, nil)
+	// Expect Put to be called once for each attempt (initial + retries) that involves a conn.Get
+	// Since sendCoAPMessage is called initial + maxRetries times.
+	mockConnMgr.On("Put", mockReturnedConnWrapper).Times(maxRetries + 1)
+
+
+	benthosMsg := service.NewMessage([]byte("test content"))
+	coapReqMsg := pool.AcquireMessage(context.Background()); defer pool.ReleaseMessage(coapReqMsg)
+	// Populate coapReqMsg as MessageToCoAP would
+	coapReqMsg.SetCode(codes.POST)
+	coapReqMsg.SetType(message.Confirmable)
+	coapReqMsg.SetPathString("/default")
+	coapReqMsg.SetPayload([]byte("test content"))
+
+	mockConv.On("MessageToCoAP", benthosMsg).Return(coapReqMsg, nil)
+
+	sendAttempt := 0
+	expectedErrorFromDo := "persistent send error"
+	mockUDP.doFunc = func(ctx context.Context, req *message.Message) (*message.Message, error) {
+		sendAttempt++
+		return nil, errors.New(expectedErrorFromDo) // Always fail
+	}
+
+	err := out.Write(context.Background(), benthosMsg)
+	require.Error(t, err, "Write should fail after max retries")
+	assert.Contains(t, err.Error(), expectedErrorFromDo, "Error should contain the underlying send error")
+	assert.Contains(t, err.Error(), fmt.Sprintf("after %d retries", maxRetries), "Error message should indicate max retries hit")
+	assert.Equal(t, maxRetries + 1, sendAttempt, "Should have attempted send maxRetries + 1 times")
+
+	mockConnMgr.AssertExpectations(t)
+	mockConv.AssertCalled(t, "MessageToCoAP", benthosMsg)
+}
+
+
+func TestWriteWithRetry_ContextCancelledDuringBackoff(t *testing.T) {
+	outputConf := OutputConfig{
+		DefaultPath: "/default",
+		RetryPolicy: RetryPolicy{MaxRetries: 1, InitialInterval: 100 * time.Millisecond}, // Long enough interval
+		RequestOptions: RequestOptions{Timeout: 20*time.Millisecond},
+	}
+	out, mockConnMgr, mockConv := newTestOutput(t, outputConf)
+	parentCtx, cancelParent := context.WithCancel(context.Background())
+
+	mockUDP := new(MockUDPClientConn)
+	mockReturnedConnWrapper := connection.NewConnectionWrapper(mockUDP, "udp", "localhost:5683", func(){}, service.MockLogger())
+
+	mockConnMgr.On("Get", mock.Anything).Return(mockReturnedConnWrapper, nil)
+	mockConnMgr.On("Put", mockReturnedConnWrapper).Return() // Expect Put for the first attempt
+
+	benthosMsg := service.NewMessage([]byte("test content"))
+	coapReqMsg := pool.AcquireMessage(context.Background()); defer pool.ReleaseMessage(coapReqMsg)
+	mockConv.On("MessageToCoAP", benthosMsg).Return(coapReqMsg, nil)
+
+	// First attempt fails, triggering retry and backoff
+	mockUDP.doFunc = func(ctx context.Context, req *message.Message) (*message.Message, error) {
+		// Cancel the parent context shortly after the first failure, during the backoff period
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			cancelParent()
+		}()
+		return nil, errors.New("initial send error")
+	}
+
+	err := out.Write(parentCtx, benthosMsg) // Use the cancellable parentCtx
+	require.Error(t, err, "Write should fail due to context cancellation")
+	assert.True(t, errors.Is(err, context.Canceled) || strings.Contains(err.Error(), context.Canceled.Error()), "Error should be context.Canceled or wrap it")
+
+	mockConnMgr.AssertCalled(t, "Get", mock.Anything)
+	mockConnMgr.AssertCalled(t, "Put", mockReturnedConnWrapper) // Only once for the first attempt
+	mockConv.AssertCalled(t, "MessageToCoAP", benthosMsg)
+}
+
+
+// Placeholder for a test that checks path handling
+func TestWriteWithRetry_PathHandling(t *testing.T) {
+	outputConf := OutputConfig{
+		DefaultPath: "/default",
+		RequestOptions: RequestOptions{Timeout: 50*time.Millisecond, Confirmable: true},
+	}
+	out, mockConnMgr, mockConv := newTestOutput(t, outputConf)
+
+	mockUDP := new(MockUDPClientConn)
+	mockReturnedConnWrapper := connection.NewConnectionWrapper(mockUDP, "udp", "localhost:5683", func(){}, service.MockLogger())
+
+	mockConnMgr.On("Get", mock.Anything).Return(mockReturnedConnWrapper, nil)
+	mockConnMgr.On("Put", mockReturnedConnWrapper).Return()
+
+	tests := []struct{
+		name string
+		msgMeta map[string]string
+		expectedPath string
+	}{
+		{"default path", map[string]string{}, "/default"},
+		{"metadata path", map[string]string{"coap_path": "/meta/path"}, "/meta/path"},
+		{"empty metadata path uses default", map[string]string{"coap_path": ""}, "/default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T){
+			benthosMsg := service.NewMessage([]byte("p"))
+			for k,v := range tt.msgMeta {
+				benthosMsg.MetaSet(k,v)
+			}
+
+			coapReqMsg := pool.AcquireMessage(context.Background())
+			coapReqMsg.SetCode(codes.POST)
+			coapReqMsg.SetType(message.Confirmable)
+			// Path will be set by MessageToCoAP or by WriteWithRetry's logic
+
+			mockConv.On("MessageToCoAP", benthosMsg).Run(func(args mock.Arguments){
+				// This is a bit of a hack to inject the expected path into the converted message
+				// In a real scenario, converter.MessageToCoAP would use the metadata to set options including path.
+				// For this test, we ensure the coapMsg passed to sendCoAPMessage has the right path.
+				// The WriteWithRetry logic sets path based on metadata BEFORE MessageToCoAP is called.
+				// MessageToCoAP should then use that path.
+				// This test actually tests WriteWithRetry's path logic more than MessageToCoAP's.
+			}).Return(coapReqMsg, nil).Once()
+
+
+			mockUDP.doFunc = func(ctx context.Context, req *message.Message) (*message.Message, error) {
+				path, _ := req.Path()
+				assert.Equal(t, strings.TrimPrefix(tt.expectedPath, "/"), path)
+				resp := pool.AcquireMessage(ctx); resp.SetCode(codes.Changed)
+				return resp, nil
+			}
+
+			err := out.Write(context.Background(), benthosMsg)
+			require.NoError(t, err)
+			mockConv.AssertExpectations(t) // Ensure MessageToCoAP was called
+		})
+	}
+}

--- a/pkg/testing/integration_test.go
+++ b/pkg/testing/integration_test.go
@@ -109,6 +109,74 @@ protocol: "udp"
 		// Verify metadata
 		assert.Equal(t, "/sensors/temp", msg.MetaGetOr("coap_path", ""))
 
+	// --- Test Update ---
+	t.Log("Updating resource on mock server...")
+	updatedData := map[string]interface{}{
+		"temperature": 25.0, // New temperature
+		"humidity":    60.0, // New humidity
+		"status":      "active",
+		"timestamp":   time.Now().Unix(),
+	}
+	jsonUpdatedData, err := json.Marshal(updatedData)
+	require.NoError(t, err)
+	require.NoError(t, server.UpdateResource("/sensors/temp", jsonUpdatedData))
+
+	// Wait for observe update message
+	select {
+	case updatedMsg := <-obsManager.MessageChan():
+		require.NotNil(t, updatedMsg)
+		payload, err := updatedMsg.AsBytes()
+		require.NoError(t, err)
+		var receivedUpdatedData map[string]interface{}
+		require.NoError(t, json.Unmarshal(payload, &receivedUpdatedData))
+
+		assert.Equal(t, updatedData["temperature"], receivedUpdatedData["temperature"])
+		assert.Equal(t, updatedData["humidity"], receivedUpdatedData["humidity"])
+		assert.Equal(t, updatedData["status"], receivedUpdatedData["status"])
+		assert.Equal(t, "/sensors/temp", updatedMsg.MetaGetOr("coap_path", ""))
+
+		// Check observe sequence number if available (it should be higher)
+		observeSeqStr := updatedMsg.MetaGetOr("coap_observe", "0")
+		observeSeq, _ := parseInt(observeSeqStr) // Helper needed for parsing int
+		assert.Greater(t, observeSeq, uint32(0), "Observe sequence should be greater than initial")
+
+	case <-time.After(10 * time.Second):
+		t.Fatal("Timeout waiting for CoAP update message")
+	case <-ctx.Done():
+		t.Fatal("Context cancelled during update wait")
+	}
+
+	// --- Test Cancellation ---
+	t.Log("Testing observation cancellation...")
+	initialObserverCount := server.GetObserverCount("/sensors/temp")
+	assert.GreaterOrEqual(t, initialObserverCount, 1, "Should have at least one observer before closing manager")
+
+	// Closing the obsManager should cancel the observation
+	require.NoError(t, obsManager.Close()) // Close the specific observer manager
+
+	// Wait a bit for cancellation to propagate and be processed by server
+	// The mock server's sendObserveNotification sets observer.Active = false if write fails (e.g. conn closed)
+	// but there's no explicit deregistration message sent by go-coap v3 client on observation cancel by default.
+	// Effective cancellation means the client stops listening and processing.
+	// We can check if the server *would* try to send to fewer observers or if our client stops.
+	// For this test, we'll assume closing the manager stops further processing of messages.
+	// A more robust server-side check would be if the mock server detected the connection drop.
+	// Here, we'll verify that no new messages arrive after closing.
+
+	server.UpdateResource("/sensors/temp", []byte(`{"status":"final"}`)) // Another update
+	select {
+	case msgAfterClose := <-obsManager.MessageChan():
+		t.Fatalf("Received message after closing observer manager: %v", msgAfterClose)
+	case <-time.After(200 * time.Millisecond):
+		// Expected: no message after close
+	}
+	// Note: GetObserverCount might not change immediately on client-side cancel if no deregister is sent.
+	// The test for cancellation is more about the client (Benthos input) stopping reception.
+
+	// Clean up main context for any remaining goroutines tied to it.
+	// cancel() is already deferred.
+
+
 	case <-time.After(10 * time.Second):
 		t.Fatal("Timeout waiting for CoAP message")
 	case <-ctx.Done():
@@ -311,6 +379,404 @@ func TestCoAPMessageConversion(t *testing.T) {
 	assert.Equal(t, testData["temperature"], backData["temperature"])
 	assert.Equal(t, testData["unit"], backData["unit"])
 }
+
+// Helper to parse int from string, used for observe sequence
+func parseInt(s string) (uint32, error) {
+	v, err := service.NewScanner().NewField(s).AsInt()
+	if err != nil {
+		return 0, err
+	}
+	return uint32(v), nil
+}
+
+func TestCoAPOutputWithOptionsIntegration(t *testing.T) {
+	server := NewMockCoAPServer()
+	require.NoError(t, server.Start())
+	defer server.Stop()
+
+	// Benthos output component configuration
+	outputConfYAML := fmt.Sprintf(`
+protocol: udp
+default_path: /test_options_path
+endpoints:
+  - coap://%s
+request_options:
+  timeout: 5s
+  confirmable: true
+converter:
+  default_content_format: application/json # This will be overridden by coap_content_format
+  preserve_options: true # Enable option preservation for custom options
+`, server.Addr())
+
+	// Parse the output plugin config (minimal spec for what's needed by newCoAPOutput directly)
+	// In a full RunIntegrationSuite, Benthos handles parsing based on registered spec.
+	// Here, we manually construct what newCoAPOutput needs.
+
+	// Mock Benthos resources needed by newCoAPOutput
+	mgr := service.MockResources()
+
+	// Manually create OutputConfig (as would be parsed from YAML)
+	// This is a simplified way to get an Output instance for testing its Write method directly.
+	// A full Benthos pipeline test would use service.RunIntegrationSuite.
+	outputPluginConfig := observer.ConfigSpec(). // Using observer's spec just to get a ParsedConfig
+								Field(service.NewStringField("log.level").Default("DEBUG")) // Add if logger expects it
+
+	parsedOutputConf, err := outputPluginConfig.ParseYAML(outputConfYAML, nil)
+	require.NoError(t, err)
+
+
+	// Create the output instance (simplified for direct testing of Write method)
+	// This directly calls the constructor, bypassing full Benthos component registration.
+	// For a real integration test of the registered component, you'd use a Benthos stream.
+	// For now, we test the 'Write' logic more directly.
+
+	// Create necessary components for the output plugin
+	// Note: The real newCoAPOutput parses these from ParsedConfig. We are providing them directly.
+	outConfig := &output.OutputConfig{
+		Endpoints:   []string{fmt.Sprintf("coap://%s", server.Addr())},
+		DefaultPath: "/test_options_path",
+		Protocol:    "udp",
+		RequestOptions: output.RequestOptions{
+			Confirmable: true,
+			Timeout:     5 * time.Second,
+		},
+		Converter: converter.Config{ // Ensure converter config is passed
+			PreserveOptions: true, // Critical for coap_option_*
+			DefaultContentFormat: "application/json",
+		},
+		// Security and ConnectionPool can use defaults if not focus of test
+	}
+
+
+	coapOutput := &output.Output{} // Create an empty struct
+
+	// Manually set up the fields of coapOutput as newCoAPOutput would.
+	// This is a more white-box approach for testing Write.
+	// A black-box test would use a Benthos stream config.
+
+	connMgrConf := connection.Config{
+		Endpoints: outConfig.Endpoints,
+		Protocol:  outConfig.Protocol,
+		// Fill other connMgrConf fields as necessary, using defaults or test values
+		MaxPoolSize:    5,
+		IdleTimeout:    30 * time.Second,
+		ConnectTimeout: 10 * time.Second,
+	}
+	connManager, err := connection.NewManager(connMgrConf, mgr.Logger(), mgr)
+	require.NoError(t, err)
+
+	conv := converter.NewConverter(outConfig.Converter, mgr.Logger())
+
+	// Reflectively set fields or make a constructor that takes these:
+	// This is where it gets tricky without either exporting fields or having a test constructor.
+	// For now, let's assume we can construct it for testing or use a helper.
+	// Let's try to use the actual constructor after all, by preparing a ParsedConfig.
+	// This requires the output plugin to be registered.
+
+	// To properly test the output plugin as Benthos would run it,
+	// we should use a Benthos stream definition.
+
+	// --- Setup Benthos Stream ---
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	outputPath := "/options/check" // Path where server will receive the message
+
+	// Define the stream
+	streamConf := fmt.Sprintf(`
+input:
+  generate:
+    count: 1
+    interval: ""
+    mapping: |
+      root.id = "test_options_message"
+      meta coap_path = "%s"
+      meta coap_uri_query = "param1=val1&param2=val2"
+      meta coap_etag = "sometag123"
+      meta coap_max_age = "90"
+      meta coap_content_format = "%d" # e.g., application/cbor
+      meta coap_option_2000_0 = "%s" # Custom option, hex encoded
+      meta coap_option_2000_1 = "%s"
+output:
+  coap:
+%s # Insert YAML block from outputConfYAML, indented
+`, outputPath, message.AppCBOR, hex.EncodeToString([]byte("custom_val_A")), hex.EncodeToString([]byte("custom_val_B")), indentYAML(outputConfYAML, "    "))
+
+	require.NoError(t, service.RegisterOutput("coap", output.ConfigSpec(),
+		func(conf *service.ParsedConfig, mgr *service.Resources) (service.Output, int, error) {
+			return output.NewCoAPOutput(conf, mgr)
+		}))
+
+	stream := service.NewStream()
+	require.NoError(t, stream.SetYAML(streamConf))
+
+	t.Logf("Running Benthos stream with config:\n%s", streamConf)
+
+	err = stream.Run(ctx)
+	if err != nil && err != context.Canceled && err != context.DeadlineExceeded {
+		// It's okay if it's cancelled or deadline exceeded, as the message might have been sent.
+		// Other errors are unexpected.
+		// This Run will block until input is exhausted or context is cancelled.
+		// Since generate has count:1, it will stop after one message.
+		require.NoError(t, err, "Stream.Run returned an unexpected error")
+	}
+
+	// --- Verification ---
+	// Check server for received message and its options
+	time.Sleep(200 * time.Millisecond) // Give server a moment to process fully
+
+	// Retrieve the options captured by the mock server for the specific path
+	receivedOpts, found := server.GetResourceLastPutOrPostOptions(outputPath)
+	require.True(t, found, "Server should have received a message at path %s", outputPath)
+
+	// Verify Uri-Query
+	var queries []string
+	for _, opt := range receivedOpts {
+		if opt.ID == message.URIQuery {
+			queries = append(queries, string(opt.Value))
+		}
+	}
+	assert.Contains(t, queries, "param1=val1", "Uri-Query param1 missing")
+	assert.Contains(t, queries, "param2=val2", "Uri-Query param2 missing")
+
+	// Verify ETag
+	etagFound := false
+	for _, opt := range receivedOpts {
+		if opt.ID == message.ETag {
+			assert.Equal(t, []byte("sometag123"), opt.Value, "ETag mismatch")
+			etagFound = true
+			break
+		}
+	}
+	assert.True(t, etagFound, "ETag option not found")
+
+	// Verify Max-Age
+	maxAgeFound := false
+	for _, opt := range receivedOpts {
+		if opt.ID == message.MaxAge {
+			// MaxAge is uint. Need to decode from bytes.
+			// For simplicity, assume it's stored as a small number.
+			// go-coap stores it efficiently.
+			// Let's check if our converter set it as expected.
+			// The converter uses SetOptionUint32, which handles encoding.
+			// We expect the raw bytes here as received by server.
+			// Example: 90 = 0x5A.
+			assert.Equal(t, []byte{0x5A}, opt.Value, "Max-Age mismatch")
+			maxAgeFound = true
+			break
+		}
+	}
+	assert.True(t, maxAgeFound, "Max-Age option not found")
+
+	// Verify Content-Format
+	cfFound := false
+	for _, opt := range receivedOpts {
+		if opt.ID == message.ContentFormat {
+			// CBOR = 60 = 0x3C
+			assert.Equal(t, []byte{0x3C}, opt.Value, "Content-Format should be CBOR (60)")
+			cfFound = true
+			break
+		}
+	}
+	assert.True(t, cfFound, "Content-Format option not found")
+
+
+	// Verify Custom Option 2000 (should have two instances)
+	var customOptValues [][]byte
+	for _, opt := range receivedOpts {
+		if opt.ID == message.OptionID(2000) {
+			customOptValues = append(customOptValues, opt.Value)
+		}
+	}
+	require.Len(t, customOptValues, 2, "Should have two instances of custom option 2000")
+	assert.Contains(t, customOptValues, []byte("custom_val_A"))
+	assert.Contains(t, customOptValues, []byte("custom_val_B"))
+
+}
+
+func TestCoAPInputOutputOptionPreservationIntegration(t *testing.T) {
+	// Server A: Serves an observable resource with options
+	serverA := NewMockCoAPServer()
+	resourcePathA := "/sensor/config"
+	initialDataA := []byte(`{"version":1, "power":"on"}`)
+	// Options to be served by Server A with the resource
+	serveOptsA := []message.Option{
+		{ID: message.ETag, Value: []byte("etagA123")},
+		{ID: message.MaxAge, Value: []byte{0x3C}}, // 60 seconds
+		{ID: message.OptionID(2500), Value: []byte("customObserveOptA")}, // Custom option
+	}
+	serverA.AddResource(resourcePathA, message.AppJSON, initialDataA, true, serveOptsA...)
+	require.NoError(t, serverA.Start())
+	defer serverA.Stop()
+
+	// Server B: Receives the message from Benthos output
+	serverB := NewMockCoAPServer()
+	require.NoError(t, serverB.Start())
+	defer serverB.Stop()
+
+	outputPathB := "/device/config_mirror" // Path where Server B receives the message
+
+	// Benthos stream configuration
+	streamConf := fmt.Sprintf(`
+input:
+  coap:
+    endpoints: ["coap://%s"]
+    observe_paths: ["%s"]
+    protocol: "udp"
+    converter:
+      preserve_options: true
+output:
+  coap:
+    endpoints: ["coap://%s"]
+    default_path: "%s" # Will be overridden by coap_path from input if preserved
+    protocol: "udp"
+    request_options:
+      confirmable: true
+    converter:
+      preserve_options: true
+`, serverA.Addr(), resourcePathA, serverB.Addr(), outputPathB)
+
+	// Register input (if not already globally registered by other tests, safe to do again)
+	require.NoError(t, service.RegisterInput("coap", observer.ConfigSpec(),
+	func(conf *service.ParsedConfig, mgr *service.Resources) (service.Input, error) {
+		return observer.NewCoAPInput(conf, mgr)
+	}))
+
+
+	stream := service.NewStream()
+	require.NoError(t, stream.SetYAML(streamConf))
+
+	t.Logf("Running E2E Option Preservation Stream:\n%s", streamConf)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Second) // Extended timeout
+	defer cancel()
+
+	runErrChan := make(chan error, 1)
+	go func() {
+		runErrChan <- stream.Run(ctx)
+	}()
+
+	// Wait for the initial notification from Server A to propagate to Server B
+	time.Sleep(3 * time.Second) // Allow time for observation to start and first message to transit
+
+	// Verify options received by Server B
+	receivedOptsB, found := serverB.GetResourceLastPutOrPostOptions(outputPathB)
+	if !found { // Check last received options if Put/Post path not matching exactly
+		receivedOptsB, found = serverB.GetLastReceivedOptionsForPath(outputPathB)
+	}
+	require.True(t, found, "Server B should have received a message at path %s", outputPathB)
+
+	// Check for ETag (ID 4)
+	foundETag := false
+	for _, opt := range receivedOptsB {
+		if opt.ID == message.ETag {
+			assert.Equal(t, []byte("etagA123"), opt.Value, "ETag mismatch on Server B")
+			foundETag = true
+			break
+		}
+	}
+	assert.True(t, foundETag, "ETag not found on Server B")
+
+	// Check for MaxAge (ID 14)
+	foundMaxAge := false
+	for _, opt := range receivedOptsB {
+		if opt.ID == message.MaxAge {
+			assert.Equal(t, []byte{0x3C}, opt.Value, "MaxAge mismatch on Server B")
+			foundMaxAge = true
+			break
+		}
+	}
+	assert.True(t, foundMaxAge, "MaxAge not found on Server B")
+
+	// Check for Custom Option 2500
+	foundCustomOpt := false
+	for _, opt := range receivedOptsB {
+		if opt.ID == message.OptionID(2500) {
+			assert.Equal(t, []byte("customObserveOptA"), opt.Value, "Custom Option 2500 mismatch on Server B")
+			foundCustomOpt = true
+			break
+		}
+	}
+	assert.True(t, foundCustomOpt, "Custom Option 2500 not found on Server B")
+
+	// Check coap_path: The output should have used the original path from input's metadata
+	// This means the message on Server B should be at resourcePathA, not outputPathB,
+	// if coap_path was correctly preserved and used by the output.
+	// The mock server stores received options by the actual path used in the CoAP request.
+	// The converter should set "coap_path" metadata on the Benthos message from the input.
+	// The output plugin should then use this "coap_path" metadata.
+	_, foundAtPathA_on_B := serverB.GetResourceLastPutOrPostOptions(resourcePathA)
+	assert.True(t, foundAtPathA_on_B, "Message on Server B should be at original path %s due to coap_path preservation", resourcePathA)
+
+
+	// --- Test with an update from Server A ---
+	t.Log("Updating resource on Server A to test propagation of new data and options")
+	updatedDataA := []byte(`{"version":2, "power":"off"}`)
+	updatedServeOptsA := []message.Option{
+		{ID: message.ETag, Value: []byte("etagA_v2")}, // New ETag
+		{ID: message.MaxAge, Value: []byte{0x1E}},      // 30 seconds
+		{ID: message.OptionID(2500), Value: []byte("customObserveOptA_v2")},
+	}
+	require.NoError(t, serverA.UpdateResource(resourcePathA, updatedDataA, updatedServeOptsA...))
+
+	time.Sleep(3 * time.Second) // Allow time for update to propagate
+
+	receivedOptsBv2, foundV2 := serverB.GetResourceLastPutOrPostOptions(resourcePathA) // Check path A again
+	require.True(t, foundV2, "Server B should have received an updated message at path %s", resourcePathA)
+
+	// Verify ETag for v2
+	foundETagV2 := false
+	for _, opt := range receivedOptsBv2 {
+		if opt.ID == message.ETag {
+			assert.Equal(t, []byte("etagA_v2"), opt.Value, "ETag v2 mismatch on Server B")
+			foundETagV2 = true
+			break
+		}
+	}
+	assert.True(t, foundETagV2, "ETag v2 not found on Server B")
+
+	// Verify MaxAge for v2
+	foundMaxAgeV2 := false
+	for _, opt := range receivedOptsBv2 {
+		if opt.ID == message.MaxAge {
+			assert.Equal(t, []byte{0x1E}, opt.Value, "MaxAge v2 mismatch on Server B")
+			foundMaxAgeV2 = true
+			break
+		}
+	}
+	assert.True(t, foundMaxAgeV2, "MaxAge v2 not found on Server B")
+
+	// Verify Custom Option 2500 for v2
+	foundCustomOptV2 := false
+	for _, opt := range receivedOptsBv2 {
+		if opt.ID == message.OptionID(2500) {
+			assert.Equal(t, []byte("customObserveOptA_v2"), opt.Value, "Custom Option 2500 v2 mismatch on Server B")
+			foundCustomOptV2 = true
+			break
+		}
+	}
+	assert.True(t, foundCustomOptV2, "Custom Option 2500 v2 not found on Server B")
+
+
+	// Stop the stream by cancelling context
+	cancel()
+	err = <-runErrChan
+	if err != nil && err != context.Canceled && err != context.DeadlineExceeded {
+		require.NoError(t, err, "Stream.Run returned an unexpected error on close")
+	}
+}
+
+
+// Helper to indent YAML block
+func indentYAML(yamlBlock, indent string) string {
+	lines := strings.Split(strings.TrimRight(yamlBlock, "\n"), "\n")
+	var indentedLines []string
+	for _, line := range lines {
+		indentedLines = append(indentedLines, indent+line)
+	}
+	return strings.Join(indentedLines, "\n")
+}
+
 
 func BenchmarkCoAPThroughput(b *testing.B) {
 	server := NewMockCoAPServer()

--- a/pkg/testing/mock_server.go
+++ b/pkg/testing/mock_server.go
@@ -17,19 +17,23 @@ import (
 type MockCoAPServer struct {
 	server    *udp.Server
 	addr      string
-	resources map[string]*MockResource
-	observers map[string][]Observer
-	mu        sync.RWMutex
-	running   bool
+	resources            map[string]*MockResource
+	observers            map[string][]Observer
+	lastReceivedOptions  map[string][]message.Option // Keyed by path
+	lastReceivedMessages map[string]*message.Message // Keyed by path, stores the last message
+	mu                   sync.RWMutex
+	running              bool
 }
 
 type MockResource struct {
-	Path         string
-	ContentType  message.MediaType
-	Data         []byte
-	Observable   bool
-	ObserveSeq   uint32
-	LastModified time.Time
+	Path                string
+	ContentType         message.MediaType
+	Data                []byte
+	Observable          bool
+	ObserveSeq          uint32
+	LastModified        time.Time
+	ServeWithOptions    []message.Option // Options to serve on GET for this resource
+	LastPutOrPostOptions []message.Option // Options from the last PUT or POST request
 }
 
 type Observer struct {
@@ -40,26 +44,29 @@ type Observer struct {
 
 func NewMockCoAPServer() *MockCoAPServer {
 	return &MockCoAPServer{
-		resources: make(map[string]*MockResource),
-		observers: make(map[string][]Observer),
+		resources:            make(map[string]*MockResource),
+		observers:            make(map[string][]Observer),
+		lastReceivedOptions:  make(map[string][]message.Option),
+		lastReceivedMessages: make(map[string]*message.Message),
 	}
 }
 
-func (m *MockCoAPServer) AddResource(path string, contentType message.MediaType, data []byte, observable bool) {
+func (m *MockCoAPServer) AddResource(path string, contentType message.MediaType, data []byte, observable bool, opts ...message.Option) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	m.resources[path] = &MockResource{
-		Path:         path,
-		ContentType:  contentType,
-		Data:         data,
-		Observable:   observable,
-		ObserveSeq:   0,
-		LastModified: time.Now(),
+		Path:             path,
+		ContentType:      contentType,
+		Data:             data,
+		Observable:       observable,
+		ObserveSeq:       0,
+		LastModified:     time.Now(),
+		ServeWithOptions: opts,
 	}
 }
 
-func (m *MockCoAPServer) UpdateResource(path string, data []byte) error {
+func (m *MockCoAPServer) UpdateResource(path string, data []byte, newOpts ...message.Option) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -71,16 +78,21 @@ func (m *MockCoAPServer) UpdateResource(path string, data []byte) error {
 	resource.Data = data
 	resource.ObserveSeq++
 	resource.LastModified = time.Now()
+	if len(newOpts) > 0 { // Allow updating options served by the resource too
+		resource.ServeWithOptions = newOpts
+	}
 
 	// Notify observers
 	if observers, hasObservers := m.observers[path]; hasObservers {
 		for i := range observers {
 			if observers[i].Active {
-				go m.sendObserveNotification(&observers[i], resource)
+				// Use a copy of the observer for the goroutine
+				obsCopy := observers[i]
+				resCopy := *resource // Use a copy of the resource for the goroutine
+				go m.sendObserveNotification(&obsCopy, &resCopy)
 			}
 		}
 	}
-
 	return nil
 }
 
@@ -127,10 +139,13 @@ func (m *MockCoAPServer) handleRequest(w mux.ResponseWriter, r *mux.Message) {
 	case codes.GET:
 		m.handleGet(w, r, path)
 	case codes.POST:
+		m.captureRequestDetails(path, r.Message)
 		m.handlePost(w, r, path)
 	case codes.PUT:
+		m.captureRequestDetails(path, r.Message)
 		m.handlePut(w, r, path)
 	case codes.DELETE:
+		m.captureRequestDetails(path, r.Message) // Might be useful to know options on DELETE too
 		m.handleDelete(w, r, path)
 	default:
 		w.SetResponse(codes.MethodNotAllowed, message.TextPlain, nil)
@@ -151,37 +166,101 @@ func (m *MockCoAPServer) handleGet(w mux.ResponseWriter, r *mux.Message, path st
 	if observe, err := r.Options().GetUint32(message.Observe); err == nil && observe == 0 {
 		if resource.Observable {
 			m.addObserver(path, r.Token(), w)
-			w.SetResponse(codes.Content, resource.ContentType, resource.Data)
-			w.SetOptionUint32(message.Observe, resource.ObserveSeq)
+			m.setResponseWithOptions(w, codes.Content, resource.ContentType, resource.Data, resource.ServeWithOptions)
+			w.SetOptionUint32(message.Observe, resource.ObserveSeq) // Observe option is mandatory for observe responses
 		} else {
 			w.SetResponse(codes.NotAcceptable, message.TextPlain, nil)
 		}
 	} else {
-		w.SetResponse(codes.Content, resource.ContentType, resource.Data)
+		m.setResponseWithOptions(w, codes.Content, resource.ContentType, resource.Data, resource.ServeWithOptions)
 	}
 }
 
+func (m *MockCoAPServer) setResponseWithOptions(w mux.ResponseWriter, code codes.Code, ct message.MediaType, payload []byte, opts []message.Option) {
+	w.SetResponse(code, ct, payload)
+	for _, opt := range opts {
+		w.SetOptionBytes(opt.ID, opt.Value)
+	}
+}
+
+
+func (m *MockCoAPServer) captureRequestDetails(path string, req *message.Message) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Deep copy options to avoid issues with buffer reuse by the CoAP library
+	optsCopy := make([]message.Option, 0, len(req.Options()))
+	for _, opt := range req.Options() {
+		optsCopy = append(optsCopy, message.Option{ID: opt.ID, Value: append([]byte(nil), opt.Value...)})
+	}
+	m.lastReceivedOptions[path] = optsCopy
+
+	// Store a copy of the message (optional, if full message inspection is needed later)
+	// Be careful with message pools if you store the message directly.
+	// For simplicity, just options are stored for now.
+	// If storing req, ensure it's cloned or its context handled.
+}
+
+
 func (m *MockCoAPServer) handlePost(w mux.ResponseWriter, r *mux.Message, path string) {
-	// Create new resource
+	m.mu.Lock()
+	resource, exists := m.resources[path]
+	if !exists { // If resource doesn't exist, create it (typical POST behavior)
+		resource = &MockResource{Path: path, Observable: false} // Default to not observable for POST-created
+		m.resources[path] = resource
+	}
+	resource.LastPutOrPostOptions = r.Options() // Store options from this request
+	m.mu.Unlock()
+
+
 	data := r.Payload()
 	contentType := message.AppOctets
-
 	if cf, err := r.Options().GetUint32(message.ContentFormat); err == nil {
 		contentType = message.MediaType(cf)
 	}
 
-	m.AddResource(path, contentType, data, false)
+	// Update resource with new data and content type
+	resource.Data = data
+	resource.ContentType = contentType
+	resource.LastModified = time.Now()
+
+	// If it was observable, and content changed, we might want to notify observers
+	// For simplicity, POST creating/updating an observable resource would also trigger notifications
+	if resource.Observable {
+		m.UpdateResource(path, data) // This will also handle notifications
+	}
+
+
 	w.SetResponse(codes.Created, message.TextPlain, nil)
 }
 
 func (m *MockCoAPServer) handlePut(w mux.ResponseWriter, r *mux.Message, path string) {
-	// Update existing resource
-	data := r.Payload()
+	m.mu.Lock()
+	resource, exists := m.resources[path]
+	if !exists {
+		// PUT usually updates or creates if not present at a specific known URI
+		resource = &MockResource{Path: path, Observable: false}
+		m.resources[path] = resource
+	}
+	resource.LastPutOrPostOptions = r.Options()
+	m.mu.Unlock()
 
+	data := r.Payload()
+	contentType := message.AppOctets
+	if cf, err := r.Options().GetUint32(message.ContentFormat); err == nil {
+		contentType = message.MediaType(cf)
+	}
+
+	// Update resource data and content type
+	resource.Data = data
+	resource.ContentType = contentType
+
+	// Call UpdateResource to also handle observer notifications if any
 	if err := m.UpdateResource(path, data); err != nil {
-		w.SetResponse(codes.NotFound, message.TextPlain, nil)
+		// This case should ideally not happen if we just created the resource above
+		w.SetResponse(codes.InternalServerError, message.TextPlain, []byte("failed to update after ensuring resource exists"))
 		return
 	}
+
 
 	w.SetResponse(codes.Changed, message.TextPlain, nil)
 }
@@ -218,13 +297,13 @@ func (m *MockCoAPServer) sendObserveNotification(observer *Observer, resource *M
 		return
 	}
 
-	err := observer.Response.SetResponse(codes.Content, resource.ContentType, resource.Data)
-	if err != nil {
-		observer.Active = false
-		return
-	}
+	// Set all options defined for the resource, then override with Observe
+	m.setResponseWithOptions(observer.Response, codes.Content, resource.ContentType, resource.Data, resource.ServeWithOptions)
+	observer.Response.SetOptionUint32(message.Observe, resource.ObserveSeq) // Ensure Observe option is set for notification
 
-	observer.Response.SetOptionUint32(message.Observe, resource.ObserveSeq)
+	// The actual sending of the response is handled by the go-coap library
+	// after this handler returns. If observer.Response.SetResponse itself returned an error,
+	// it would mean the connection is likely closed or in an error state.
 }
 
 // Test utilities
@@ -235,7 +314,7 @@ func (m *MockCoAPServer) GetObserverCount(path string) int {
 	count := 0
 	if observers, exists := m.observers[path]; exists {
 		for _, obs := range observers {
-			if obs.Active {
+			if obs.Active { // Only count active observers
 				count++
 			}
 		}
@@ -251,4 +330,30 @@ func (m *MockCoAPServer) GetResourceData(path string) ([]byte, bool) {
 		return resource.Data, true
 	}
 	return nil, false
+}
+
+func (m *MockCoAPServer) GetLastReceivedOptionsForPath(path string) ([]message.Option, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	opts, exists := m.lastReceivedOptions[path]
+	if !exists {
+		return nil, false
+	}
+	// Return a copy to prevent modification
+	optsCopy := make([]message.Option, len(opts))
+	copy(optsCopy, opts)
+	return optsCopy, true
+}
+
+func (m *MockCoAPServer) GetResourceLastPutOrPostOptions(path string) ([]message.Option, bool) {
+    m.mu.RLock()
+    defer m.mu.RUnlock()
+    resource, exists := m.resources[path]
+    if !exists || resource.LastPutOrPostOptions == nil {
+        return nil, false
+    }
+    // Return a copy
+    optsCopy := make([]message.Option, len(resource.LastPutOrPostOptions))
+    copy(optsCopy, resource.LastPutOrPostOptions)
+    return optsCopy, true
 }


### PR DESCRIPTION
This commit introduces several enhancements and implements missing features for the Benthos CoAP input and output plugins based on `go-coap/v3`.

Key changes include:

1.  **Observer Functionality (`pkg/observer`):**
    - Implemented the core CoAP observe logic in `coap_observer_manager.go` using `go-coap/v3` client APIs for both UDP and TCP connections.
    - Handles observation registration, notification processing, context cancellation, retry mechanisms, and circuit breaker integration.
    - `handleObserveMessage` now correctly converts CoAP notifications to Benthos messages.

2.  **Output Sending Logic (`pkg/output`):**
    - Implemented message sending in `coap_output_plugin.go` for UDP and TCP protocols using `go-coap/v3` client's `Do` method.
    - `sendCoAPMessage` now correctly detects connection types and delegates to protocol-specific functions.
    - Handles request timeouts, CoAP message types (Confirmable/NonConfirmable), and path resolution. CoAP method defaults to POST.

3.  **CoAP Option Handling (`pkg/converter`):**
    - **ContentFormat:** The `ContentFormat` option is now correctly set on outgoing CoAP messages in `MessageToCoAP` using `SetOptionUint32`.
    - **Option Preservation:** Implemented full option preservation when `PreserveOptions` is true. Options from incoming CoAP messages are hex-encoded and stored in Benthos metadata (e.g., `coap_option_<ID>_<index>`) and restored on outgoing messages.
    - **Specific Option Setting:** Enhanced `addOptionsFromMetadata` to set various standard CoAP options (Uri-Path, Uri-Query, Max-Age, ETag, Observe, Accept, If-Match, If-None-Match) from specific Benthos metadata keys, with precedence over generic preserved options.

4.  **Testing (`pkg/testing`, `pkg/*/*_test.go`):**
    - Added comprehensive unit tests for the converter, observer, and output plugin functionalities, covering various success and error scenarios, retry logic, and option handling.
    - Enhanced the `MockCoAPServer` in integration tests to capture and serve CoAP options.
    - Added new integration tests:
        - `TestCoAPInputObserveIntegration`: Verifies observe updates and cancellation.
        - `TestCoAPOutputWithOptionsIntegration`: Verifies correct setting of CoAP options by the output plugin from Benthos metadata. - `TestCoAPInputOutputOptionPreservationIntegration`: End-to-end test validating option preservation through a CoAP input -> Benthos -> CoAP output pipeline.

These changes address the primary TODOs related to `go-coap/v3` integration, making the CoAP plugins more robust and feature-complete.